### PR TITLE
Use `Schema.Types` for schema type

### DIFF
--- a/framework/lib/Models/GuildSchema.ts
+++ b/framework/lib/Models/GuildSchema.ts
@@ -5,27 +5,27 @@ const guildSchema = new Schema<IGuildSchema>({
     createdAt: {
         default: new Date(),
         required: true,
-        type: Date
+        type: Schema.Types.Date
     },
     id: {
         required: true,
-        type: String
+        type: Schema.Types.String
     },
     settings: {
         blacklisted: {
             default: false,
             required: true,
-            type: Boolean
+            type: Schema.Types.Boolean
         },
         locale: {
             default: "en",
             required: true,
-            type: String
+            type: Schema.Types.String
         },
         whitelisted: {
             default: false,
             required: true,
-            type: Boolean
+            type: Schema.Types.Boolean
         }
     }
 });

--- a/framework/lib/Models/UserSchema.ts
+++ b/framework/lib/Models/UserSchema.ts
@@ -1,31 +1,30 @@
 import { model, Model, Schema } from "mongoose";
 import { IUserSchema } from "../Interfaces";
-
 const userSchema = new Schema<IUserSchema>({
     bookmark: {
         default: [],
         required: true,
-        type: [String]
+        type: Schema.Types.Mixed
     },
     createdAt: {
         default: new Date(),
         required: true,
-        type: Date
+        type: Schema.Types.Date
     },
     id: {
         required: true,
-        type: String
+        type: Schema.Types.String
     },
     settings: {
         premium: {
             default: false,
             required: true,
-            type: Boolean
+            type: Schema.Types.Boolean
         },
         readState: {
             default: "current",
             required: true,
-            type: String
+            type: Schema.Types.String
         }
     }
 });


### PR DESCRIPTION
`UserSchema.bookmark` type is now `Book[]` instead of `string[]`. This will now allow the bot to fetch bookmarked books from the database instead of having to send an API request in a short period.