### PR TITLE
Defer interactions correctly

### DIFF
--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -6,6 +6,7 @@ import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { Utils } from "givies-framework";
 import { UserModel } from "../../Models";
 import { createBookmarkPaginator } from "../../Modules/BookmarkPaginator";
+import { setTimeout } from "node:timers/promises";
 
 export async function bookmarkCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
@@ -40,7 +41,8 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
             });
         }
 
-        interaction.defer();
+        await interaction.defer();
+        await setTimeout(4000);
 
         const bookmarkedTitle: string[] = [];
         const books: Book[] = [];

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -42,7 +42,7 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
         }
 
         await interaction.defer();
-        await setTimeout(4000);
+        await setTimeout(2000);
 
         const bookmarkedTitle: string[] = [];
         const books: Book[] = [];

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -23,7 +23,7 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
     }
 
     await interaction.defer();
-    await setTimeout(4000);
+    await setTimeout(2000);
 
     api.getBook(args.id).then(async (book) => {
         const guildData = await GuildModel.findOne({ id: interaction.guildID });

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -7,8 +7,9 @@ import { GuildModel } from "../../Models";
 import { createReadPaginator } from "../../Modules/ReadPaginator";
 import { Utils } from "givies-framework";
 import moment from "moment";
+import { setTimeout } from "node:timers/promises";
 
-export function readCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function readCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
     jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
 
@@ -20,6 +21,9 @@ export function readCommand(client: NReaderClient, interaction: CommandInteracti
     for (const option of interaction.data.options) {
         args[option.name] = (option as any).value as string;
     }
+
+    await interaction.defer();
+    await setTimeout(4000);
 
     api.getBook(args.id).then(async (book) => {
         const guildData = await GuildModel.findOne({ id: interaction.guildID });

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -6,6 +6,7 @@ import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { Utils } from "givies-framework";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
+import { setTimeout } from "node:timers/promises";
 
 export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
@@ -33,6 +34,9 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }
+
+    await interaction.defer();
+    await setTimeout(4000);
 
     api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1).then(async (search) => {
         if (search.books.length === 0) {

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -36,7 +36,7 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
     }
 
     await interaction.defer();
-    await setTimeout(4000);
+    await setTimeout(2000);
 
     api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1).then(async (search) => {
         if (search.books.length === 0) {

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -6,6 +6,7 @@ import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { Utils } from "givies-framework";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
+import { setTimeout } from "node:timers/promises";
 
 export async function searchSimilarCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
     const jar = new CookieJar();
@@ -33,6 +34,9 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }
+
+    await interaction.defer();
+    await setTimeout(4000);
 
     api.searchAlike(args.id).then(async (search) => {
         if (search.books.length === 0) {

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -36,7 +36,7 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
     }
 
     await interaction.defer();
-    await setTimeout(4000);
+    await setTimeout(2000);
 
     api.searchAlike(args.id).then(async (search) => {
         if (search.books.length === 0) {


### PR DESCRIPTION
I had opened 3 pull requests regarding this and yet I had to revert them all. However, this should really fix the main issue of interactions aren't responding.

From what I've seen from the logs, it seems that this issue occurs depending on the circumstances. Interaction defer won't work when there's no network interruption between the client and the API however, interaction defer is needed when API fetch takes more than 3 seconds to finish. 

In the end, I implemented a timeout of up to 4 seconds to defer and let it do the rest. Although this is recommended to do on all Discord bots yet, I never noticed.