### PR TITLE
Remove `main.search.titles` on embed description

### DIFF
--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -53,7 +53,7 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
 
         const embed = new Utils.RichEmbed()
             .setColor(client.config.BOT.COLOUR)
-            .setDescription(client.translate("main.search.titles", { titles: title.join("\n") }))
+            .setDescription(title.join("\n"))
             .setTitle(client.translate("main.page", { firstIndex: search.page, lastIndex: search.pages.toLocaleString() }));
 
         const component: ActionRow = {

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -53,7 +53,7 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
 
         const embed = new Utils.RichEmbed()
             .setColor(client.config.BOT.COLOUR)
-            .setDescription(client.translate("main.search.titles", { titles: title.join("\n") }))
+            .setDescription(title.join("\n"))
             .setTitle(client.translate("main.page", { firstIndex: search.page, lastIndex: search.pages }));
 
         const component: ActionRow = {


### PR DESCRIPTION
Search results should display organised on the mobile platforms as well.