### PR TITLE
Use `Client.api` instead of creating new class

### DIFF
--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -1,5 +1,8 @@
+import { API } from "nhentai-api";
+import { CookieJar } from "tough-cookie";
 import { Client, ClientEvents, TextableChannel } from "eris";
 import { Collection } from "./Utils";
+import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { ICommand, IConfig, IEvent, IGuildSchemaSettings } from "./Interfaces";
 import { TLocale } from "./Types";
 import { Utils } from "givies-framework";
@@ -35,6 +38,21 @@ export class NReaderClient extends Client {
      * Logger
      */
     public logger = new Utils.Logger();
+
+    /**
+     * NHentai API
+     */
+    public get api() {
+        const jar = new CookieJar();
+        jar.setCookie(this.config.API.COOKIE, "https://nhentai.net");
+
+        const agent = new HttpsCookieAgent({ cookies: { jar } });
+
+        /* @ts-ignore */
+        const api = new API({ agent });
+
+        return api;
+    }
 
     /**
      * Collect messages in a channel

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -1,21 +1,12 @@
 import { NReaderClient } from "../../Client";
 import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { API, Book } from "nhentai-api";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
+import { Book } from "nhentai-api";
 import { Utils } from "givies-framework";
 import { UserModel } from "../../Models";
 import { createBookmarkPaginator } from "../../Modules/BookmarkPaginator";
 import { setTimeout } from "node:timers/promises";
 
 export async function bookmarkCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const jar = new CookieJar();
-    jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-
-    const agent = new HttpsCookieAgent({ cookies: { jar } });
-    // @ts-ignore
-    const api = new API({ agent });
-
     const args: { user?: string } = {};
 
     if (interaction.data.options) {
@@ -48,8 +39,8 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
         const books: Book[] = [];
 
         for (let i = 0; i < bookmarked.length; i++) {
-            const title = await api.getBook(parseInt(bookmarked[i])).then((book) => `\`⬛ ${(i + 1).toString().length > 1 ? `${i + 1}`  : `${i + 1} `}\` - [\`${book.id}\`](https://nhentai.net/g/${book.id}) - \`${book.title.pretty}\``);
-            const book = await api.getBook(parseInt(bookmarked[i]));
+            const title = await client.api.getBook(parseInt(bookmarked[i])).then((book) => `\`⬛ ${(i + 1).toString().length > 1 ? `${i + 1}`  : `${i + 1} `}\` - [\`${book.id}\`](https://nhentai.net/g/${book.id}) - \`${book.title.pretty}\``);
+            const book = await client.api.getBook(parseInt(bookmarked[i]));
 
             books.push(book);
             bookmarkedTitle.push(title);

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -1,20 +1,11 @@
 import { NReaderClient } from "../../Client";
 import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { API } from "nhentai-api";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { GuildModel } from "../../Models";
 import { createReadPaginator } from "../../Modules/ReadPaginator";
 import { Utils } from "givies-framework";
 import { setTimeout } from "node:timers/promises";
 
 export async function readCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const jar = new CookieJar();
-    jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-
-    const agent = new HttpsCookieAgent({ cookies: { jar } });
-    // @ts-ignore
-    const api = new API({ agent });
     const args: { id?: number } = {};
 
     for (const option of interaction.data.options) {
@@ -24,7 +15,7 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
     await interaction.defer();
     await setTimeout(2000);
 
-    api.getBook(args.id).then(async (book) => {
+    client.api.getBook(args.id).then(async (book) => {
         const guildData = await GuildModel.findOne({ id: interaction.guildID });
         const artistTags: string[] = book.tags.filter((tag) => tag.url.startsWith("/artist")).map((tag) => tag.name);
         const characterTags: string[] = book.tags.filter((tag) => tag.url.startsWith("/character")).map((tag) => tag.name);
@@ -57,7 +48,7 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
             .addField(parodyTags.length > 1 ? client.translate("main.parodies") : client.translate("main.parody"), `\`${parodyTags.length !== 0 ? parodyTags.join("`, `").replace("original", `${client.translate("main.original")}`) : client.translate("main.none")}\``)
             .addField(contentTags.length > 1 ? client.translate("main.tags") : client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : client.translate("main.none")}\``)
             .setFooter(`⭐ ${book.favorites.toLocaleString()}`)
-            .setThumbnail(api.getImageURL(book.cover));
+            .setThumbnail(client.api.getImageURL(book.cover));
 
         const component: ActionRow = {
             components: [

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -1,20 +1,11 @@
-import { API } from "nhentai-api";
 import { NReaderClient } from "../../Client";
 import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { Utils } from "givies-framework";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 
 export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const jar = new CookieJar();
-    jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-
-    const agent = new HttpsCookieAgent({ cookies: { jar } });
-    // @ts-ignore
-    const api = new API({ agent });
     const args: { page?: number, query?: string } = {};
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
 
@@ -38,7 +29,7 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
     await interaction.defer();
     await setTimeout(2000);
 
-    api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1).then(async (search) => {
+    client.api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1).then(async (search) => {
         if (search.books.length === 0) {
             const embed = new Utils.RichEmbed()
                 .setColor(client.config.BOT.COLOUR)

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -1,23 +1,14 @@
-import { API } from "nhentai-api";
 import { NReaderClient } from "../../Client";
 import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { Utils } from "givies-framework";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 
 export async function searchSimilarCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const jar = new CookieJar();
-    jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-
-    const agent = new HttpsCookieAgent({ cookies: { jar } });
-    // @ts-ignore
-    const api = new API({ agent });
     const args: { id?: number } = {};
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
-    const book = (await api.getBook(args.id));
+    const book = (await client.api.getBook(args.id));
     const tags = book.tags.filter((tag) => tag.url.startsWith("/tags")).map((tag) => tag.name);
 
     for (const option of interaction.data.options) {
@@ -38,7 +29,7 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
     await interaction.defer();
     await setTimeout(2000);
 
-    api.searchAlike(args.id).then(async (search) => {
+    client.api.searchAlike(args.id).then(async (search) => {
         if (search.books.length === 0) {
             const embed = new Utils.RichEmbed()
                 .setColor(client.config.BOT.COLOUR)

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -1,7 +1,5 @@
 import { API, Book } from "nhentai-api";
 import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Member, Message, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { NReaderClient } from "../Client";
 import { Utils } from "givies-framework";
 import { UserModel } from "../Models";
@@ -66,12 +64,7 @@ export class BookmarkPaginator {
      * @param interaction Eris command interaction
      */
     constructor(client: NReaderClient, books: Book[], interaction: CommandInteraction<TextableChannel>, user: Member) {
-        const jar = new CookieJar();
-        jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-        const agent = new HttpsCookieAgent({ cookies: { jar } });
-
-        // @ts-ignore
-        this.api = new API({ agent });
+        this.api = client.api;
         this.books = books;
         this.client = client;
         this.embed = 1;

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -1,7 +1,5 @@
 import { API, Book } from "nhentai-api";
 import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Message, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { NReaderClient } from "../Client";
 import { Utils } from "givies-framework";
 import { UserModel } from "../Models";
@@ -55,12 +53,7 @@ export class ReadPaginator {
      * @param interaction Eris command interaction
      */
     constructor(client: NReaderClient, book: Book, interaction: CommandInteraction<TextableChannel>) {
-        const jar = new CookieJar();
-        jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-        const agent = new HttpsCookieAgent({ cookies: { jar } });
-
-        // @ts-ignore
-        this.api = new API({ agent });
+        this.api = client.api;
         this.book = book;
         this.client = client;
         this.embed = 1;

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -1,7 +1,5 @@
 import { API, Book } from "nhentai-api";
 import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Message, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { NReaderClient } from "../Client";
 import { Utils } from "givies-framework";
 import { UserModel } from "../Models";
@@ -55,12 +53,7 @@ export class ReadSearchPaginator {
      * @param interaction Eris command interaction
      */
     constructor(client: NReaderClient, book: Book, interaction: CommandInteraction<TextableChannel>) {
-        const jar = new CookieJar();
-        jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-        const agent = new HttpsCookieAgent({ cookies: { jar } });
-
-        // @ts-ignore
-        this.api = new API({ agent });
+        this.api = client.api;
         this.book = book;
         this.client = client;
         this.embed = 1;

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -1,7 +1,5 @@
 import { API, Search } from "nhentai-api";
 import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Message, TextableChannel } from "eris";
-import { CookieJar } from "tough-cookie";
-import { HttpsCookieAgent } from "http-cookie-agent/http";
 import { NReaderClient } from "../Client";
 import { Utils } from "givies-framework";
 import { UserModel } from "../Models";
@@ -61,12 +59,7 @@ export class SearchPaginator {
      * @param interaction Eris command interaction
      */
     constructor(client: NReaderClient, search: Search, interaction: CommandInteraction<TextableChannel>) {
-        const jar = new CookieJar();
-        jar.setCookie(client.config.API.COOKIE, "https://nhentai.net/");
-        const agent = new HttpsCookieAgent({ cookies: { jar } });
-
-        // @ts-ignore
-        this.api = new API({ agent });
+        this.api = client.api;
         this.client = client;
         this.embed = 1;
         this.embeds = [];


### PR DESCRIPTION
It'll be easier to import existing API from accessible `Client` rather than creating multiples in different files.