### PR TITLE
Handle `guildDelete` event

### DIFF
--- a/bot/src/Events/GuildDelete.ts
+++ b/bot/src/Events/GuildDelete.ts
@@ -1,0 +1,9 @@
+import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { Guild } from "eris";
+
+export const event: NReaderInterface.IEvent = {
+    name: "guildDelete",
+    run: async (client, guild: Guild) => {
+        return new NReaderEvent<Guild, any, any, any>(client, guild).guildDeleteEvent();
+    }
+}

--- a/framework/lib/Events/Event.ts
+++ b/framework/lib/Events/Event.ts
@@ -66,6 +66,14 @@ export class NReaderEvent<F, S, T, L> {
     }
 
     /**
+     * Fires a `guildDelete` event
+     * @returns {void}
+     */
+    public guildDeleteEvent(): void {
+        return EventModules.guildDeleteEvent(this.client, this.firstParam);
+    }
+
+    /**
      * Fires a `interactionCreate` event
      * @returns {Promise<void>}
      */

--- a/framework/lib/Events/Modules/GuildDeleteEvent.ts
+++ b/framework/lib/Events/Modules/GuildDeleteEvent.ts
@@ -1,0 +1,6 @@
+import { NReaderClient } from "../../Client";
+import { Guild } from "eris";
+
+export function guildDeleteEvent(client: NReaderClient, guild: Guild) {
+    client.logger.info({ message: `Guild ${guild.name} (${guild.id}) Has Left`, subTitle: "NReaderFramework::Events::GuildDelete", title: "GUILDS" });
+}

--- a/framework/lib/Events/Modules/index.ts
+++ b/framework/lib/Events/Modules/index.ts
@@ -1,5 +1,6 @@
 export * from "./DebugEvent";
 export * from "./ErrorEvent";
 export * from "./GuildCreateEvent";
+export * from "./GuildDeleteEvent";
 export * from "./InteractionCreateEvent";
 export * from "./ReadyEvent";


### PR DESCRIPTION
The disconnected guild should get logged too.

- *Any disconnected guild won't get their data deleted*