### PR TITLE
Implement search sorting results

### DIFF
--- a/bot/src/Commands/Main/Search.ts
+++ b/bot/src/Commands/Main/Search.ts
@@ -9,14 +9,36 @@ export const command: NReaderInterface.ICommand = {
             name: "query",
             description: "The title query of the doujin",
             type: 3,
-            channel_types: 0,
             required: true
         },
         {
             name: "page",
             description: "Page of the results",
             type: 4,
-            channel_types: 0
+        },
+        {
+            name: "sort",
+            description: "Sort results based on the sort mode",
+            type: 3,
+            /* @ts-ignore */
+            choices: [
+                {
+                    name: "Popular All Time",
+                    value: "popular"
+                },
+                {
+                    name: "Popular Today",
+                    value: "popular-today"
+                },
+                {
+                    name: "Popular This Week",
+                    value: "popular-week"
+                },
+                {
+                    name: "Popular This Month",
+                    value: "popular-month"
+                }
+            ]
         }
     ],
     type: 1,

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -5,9 +5,10 @@ import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 import { NReaderConstant } from "../../Constant";
+import { SearchSortMode } from "nhentai-api/types/search";
 
 export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const args: { page?: number, query?: string } = {};
+    const args: { page?: number, query?: string, sort?: SearchSortMode } = {};
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
 
     for (const option of interaction.data.options) {
@@ -30,7 +31,7 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
     await interaction.defer();
     await setTimeout(2000);
 
-    client.api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1).then(async (search) => {
+    client.api.search(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1, args.sort || "").then(async (search) => {
         if (search.books.length === 0) {
             const embed = new Utils.RichEmbed()
                 .setColor(client.config.BOT.COLOUR)


### PR DESCRIPTION
The `/search` slash command now accepts the `sort` option that allows you to sort results based on the requested timeline.

- *This is optional. Leaving this option blank will sort by the most recent ones*