### PR TITLE
Import framework from the lib

### DIFF
--- a/bot/src/Commands/General/Help.ts
+++ b/bot/src/Commands/General/Help.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     description: "Display the help menu",

--- a/bot/src/Commands/General/Ping.ts
+++ b/bot/src/Commands/General/Ping.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     description: "Ping the bot",

--- a/bot/src/Commands/General/Stats.ts
+++ b/bot/src/Commands/General/Stats.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     name: "stats",

--- a/bot/src/Commands/Main/Bookmark.ts
+++ b/bot/src/Commands/Main/Bookmark.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     name: "bookmark",

--- a/bot/src/Commands/Main/Read.ts
+++ b/bot/src/Commands/Main/Read.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     description: "Read a doujin from NHentai",

--- a/bot/src/Commands/Main/Search.ts
+++ b/bot/src/Commands/Main/Search.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     name: "search",

--- a/bot/src/Commands/Main/SearchSimilar.ts
+++ b/bot/src/Commands/Main/SearchSimilar.ts
@@ -1,4 +1,4 @@
-import { NReaderCommand, NReaderInterface } from "nreader-framework";
+import { NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     name: "search-similar",

--- a/bot/src/Commands/Mod/Config.ts
+++ b/bot/src/Commands/Mod/Config.ts
@@ -1,4 +1,4 @@
-import {  NReaderCommand, NReaderInterface } from "nreader-framework";
+import {  NReaderCommand, NReaderInterface } from "nreader-framework/lib";
 
 export const command: NReaderInterface.ICommand = {
     name: "config",

--- a/bot/src/Events/Debug.ts
+++ b/bot/src/Events/Debug.ts
@@ -1,4 +1,4 @@
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "debug",

--- a/bot/src/Events/Error.ts
+++ b/bot/src/Events/Error.ts
@@ -1,4 +1,4 @@
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "error",

--- a/bot/src/Events/GuildCreate.ts
+++ b/bot/src/Events/GuildCreate.ts
@@ -1,4 +1,4 @@
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 import { Guild } from "eris";
 
 export const event: NReaderInterface.IEvent = {

--- a/bot/src/Events/GuildDelete.ts
+++ b/bot/src/Events/GuildDelete.ts
@@ -1,4 +1,4 @@
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 import { Guild } from "eris";
 
 export const event: NReaderInterface.IEvent = {

--- a/bot/src/Events/InteractionCreate.ts
+++ b/bot/src/Events/InteractionCreate.ts
@@ -1,5 +1,5 @@
 import { CommandInteraction, TextableChannel } from "eris";
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "interactionCreate",

--- a/bot/src/Events/Ready.ts
+++ b/bot/src/Events/Ready.ts
@@ -1,4 +1,4 @@
-import { NReaderEvent, NReaderInterface } from "nreader-framework";
+import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "ready",

--- a/bot/src/NReader.ts
+++ b/bot/src/NReader.ts
@@ -1,4 +1,4 @@
-import { NReaderClient } from "nreader-framework";
+import { NReaderClient } from "nreader-framework/lib";
 import * as Config from "../../config/config.json";
 
 const client = new NReaderClient(Config.BOT.TOKEN, {

--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -98,8 +98,8 @@ export class NReaderClient extends Client {
             type: 0
         });
 
-        const commandPath = join(__dirname, "..", "..", "..", "bot", "src", "Commands");
-        const eventPath = join(__dirname, "..", "..", "..", "bot", "src", "Events");
+        const commandPath = join(__dirname, "..", "..", "bot", "src", "Commands");
+        const eventPath = join(__dirname, "..", "..", "bot", "src", "Events");
 
         readdirSync(commandPath).forEach(async (dir) => {
             const commands = readdirSync(`${commandPath}/${dir}`).filter((file) => file.endsWith(".ts"));

--- a/framework/package.json
+++ b/framework/package.json
@@ -2,12 +2,11 @@
   "name": "nreader-framework",
   "version": "0.1.1",
   "description": "Read Something",
-  "main": "src/lib/index.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">=16.10.0"
   },
   "scripts": {
-    "build": "tsc && echo \"\u001b[1m\u001b[32mSUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mFAILED\u001b[39m\u001b[22m\"",
     "build:locale": "ts-node ./lib/Modules/LocalisationCompiler.ts",
     "lint": "eslint --ext \".ts\" --ignore-path .gitignore . && echo \"\u001b[1m\u001b[32mSUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mFAILED\u001b[39m\u001b[22m\"",
     "lint:fix": "eslint --ext \".ts\" --ignore-path .gitignore . --fix && echo \"\u001b[1m\u001b[32mSUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mFAILED\u001b[39m\u001b[22m\""


### PR DESCRIPTION
Took me a while that I can import the framework from the main `lib` instead of having to run the build script. I'm expecting this should fix everything related to the wrong file path.