### PR TITLE
Migrate Discord library from Eris -> Oceanic

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,9 +17,9 @@ It must be very difficult to understand the entire code base of **NReader**. How
 
 Again, if you are still confused, our [Discord Server](https://discord.gg/b7AW2Zkcsw) is available for developers!
 
-### Eris Discord Library
+### Oceanic Discord Library
 
-**NReader** is powered by the [Eris](https://github.com/abalabahaha/eris) Discord library. You need to have decent knowledge about this library if you want to make changes related to Discord mostly.
+**NReader** is powered by the [Oceanic](https://github.com/OceanicJS/Oceanic) Discord library. You need to have decent knowledge about this library if you want to make changes related to Discord mostly.
 
 ## Top Issues (Best to Get Started)
 

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -30,7 +30,6 @@
       "dependencies": {
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
-        "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
         "http-cookie-agent": "^4.0.1",
         "i18next": "^21.8.13",
         "i18next-icu": "^2.0.3",
@@ -3438,7 +3437,6 @@
         "@typescript-eslint/parser": "^5.15.0",
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
-        "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
         "eslint": "^8.11.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "eris": "^0.17.1",
-        "nreader-framework": "file:../framework"
+        "nreader-framework": "file:../framework",
+        "oceanic.js": "^1.0.2"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.32.0",
@@ -30,14 +30,14 @@
       "dependencies": {
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
-        "eris": "^0.17.1",
-        "givies-framework": "^2022.706.0",
+        "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
         "http-cookie-agent": "^4.0.1",
         "i18next": "^21.8.13",
         "i18next-icu": "^2.0.3",
-        "moment": "^2.29.1",
+        "moment": "^2.29.4",
         "mongoose": "^6.0.12",
-        "nhentai-api": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "oceanic.js": "^1.0.2",
         "os-utils": "^0.0.14",
         "tough-cookie": "^4.0.0"
       },
@@ -69,6 +69,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
+      "optional": true,
+      "dependencies": {
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.36.2",
+        "prism-media": "^1.3.4",
+        "tslib": "^2.4.0",
+        "ws": "^8.8.1"
+      },
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -227,8 +243,7 @@
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
       "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
-      "dev": true,
-      "peer": true
+      "devOptional": true
     },
     "node_modules/@types/strip-bom": {
       "version": "3.0.0",
@@ -241,6 +256,15 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",
@@ -713,6 +737,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "optional": true
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -732,21 +762,6 @@
       "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/eris": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
-      "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
-      "dependencies": {
-        "ws": "^8.2.3"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      },
-      "optionalDependencies": {
-        "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1566,6 +1581,21 @@
       "resolved": "../framework",
       "link": true
     },
+    "node_modules/oceanic.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/oceanic.js/-/oceanic.js-1.0.2.tgz",
+      "integrity": "sha512-C9Bw+Q0SQZ3j5XtUyMzVKgfd2SexoFtpEiksdoEnErA6tzi0KYLJ82vUd4YLV92WootCTgkTSPQnP0CAgzfyiA==",
+      "dependencies": {
+        "undici": "^5.10.0",
+        "ws": "^8.8.1"
+      },
+      "engines": {
+        "node": ">=16.16.0"
+      },
+      "optionalDependencies": {
+        "@discordjs/voice": "^0.11.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1596,7 +1626,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
       "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -1701,6 +1732,32 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.4.tgz",
+      "integrity": "sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==",
+      "optional": true,
+      "peerDependencies": {
+        "@discordjs/opus": "^0.8.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
       }
     },
     "node_modules/punycode": {
@@ -2074,7 +2131,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -2096,12 +2153,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2139,6 +2190,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/uri-js": {
@@ -2193,9 +2252,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2257,6 +2316,19 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@discordjs/voice": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
+      "optional": true,
+      "requires": {
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.36.2",
+        "prism-media": "^1.3.4",
+        "tslib": "^2.4.0",
+        "ws": "^8.8.1"
       }
     },
     "@eslint/eslintrc": {
@@ -2389,8 +2461,7 @@
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
       "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
-      "dev": true,
-      "peer": true
+      "devOptional": true
     },
     "@types/strip-bom": {
       "version": "3.0.0",
@@ -2403,6 +2474,15 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",
@@ -2710,6 +2790,12 @@
         "path-type": "^4.0.0"
       }
     },
+    "discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "optional": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2726,16 +2812,6 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
-      }
-    },
-    "eris": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
-      "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
-      "requires": {
-        "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.3",
-        "ws": "^8.2.3"
       }
     },
     "escape-string-regexp": {
@@ -3362,23 +3438,33 @@
         "@typescript-eslint/parser": "^5.15.0",
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
-        "eris": "^0.17.1",
+        "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
         "eslint": "^8.11.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
-        "givies-framework": "^2022.706.0",
         "http-cookie-agent": "^4.0.1",
         "i18next": "^21.8.13",
         "i18next-icu": "^2.0.3",
-        "moment": "^2.29.1",
+        "moment": "^2.29.4",
         "mongoose": "^6.0.12",
-        "nhentai-api": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "oceanic.js": "^1.0.2",
         "os-utils": "^0.0.14",
         "tough-cookie": "^4.0.0",
         "ts-node": "^10.8.2",
         "ts-node-dev": "^1.1.8",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4"
+      }
+    },
+    "oceanic.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/oceanic.js/-/oceanic.js-1.0.2.tgz",
+      "integrity": "sha512-C9Bw+Q0SQZ3j5XtUyMzVKgfd2SexoFtpEiksdoEnErA6tzi0KYLJ82vUd4YLV92WootCTgkTSPQnP0CAgzfyiA==",
+      "requires": {
+        "@discordjs/voice": "^0.11.0",
+        "undici": "^5.10.0",
+        "ws": "^8.8.1"
       }
     },
     "once": {
@@ -3408,7 +3494,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
       "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "p-limit": {
       "version": "3.1.0",
@@ -3478,6 +3565,13 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prism-media": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.4.tgz",
+      "integrity": "sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==",
+      "optional": true,
+      "requires": {}
     },
     "punycode": {
       "version": "2.1.1",
@@ -3711,7 +3805,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "devOptional": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -3729,12 +3823,6 @@
           "dev": true
         }
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "optional": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -3757,6 +3845,11 @@
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "peer": true
+    },
+    "undici": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -3801,9 +3894,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "requires": {}
     },
     "xtend": {

--- a/bot/package.json
+++ b/bot/package.json
@@ -14,8 +14,8 @@
   "author": "Reinhardt",
   "license": "MIT",
   "dependencies": {
-    "eris": "^0.17.1",
-    "nreader-framework": "file:../framework"
+    "nreader-framework": "file:../framework",
+    "oceanic.js": "^1.0.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.32.0",

--- a/bot/src/Events/GuildCreate.ts
+++ b/bot/src/Events/GuildCreate.ts
@@ -1,5 +1,5 @@
 import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
-import { Guild } from "eris";
+import { Guild } from "oceanic.js";
 
 export const event: NReaderInterface.IEvent = {
     name: "guildCreate",

--- a/bot/src/Events/GuildDelete.ts
+++ b/bot/src/Events/GuildDelete.ts
@@ -1,5 +1,5 @@
 import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
-import { Guild } from "eris";
+import { Guild } from "oceanic.js";
 
 export const event: NReaderInterface.IEvent = {
     name: "guildDelete",

--- a/bot/src/Events/InteractionCreate.ts
+++ b/bot/src/Events/InteractionCreate.ts
@@ -1,9 +1,9 @@
-import { CommandInteraction, TextableChannel } from "eris";
+import { CommandInteraction, TextChannel } from "oceanic.js";
 import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "interactionCreate",
-    run: (client, interaction: CommandInteraction<TextableChannel>) => {
-    return new NReaderEvent<CommandInteraction<TextableChannel>, any, any, any>(client, interaction).interactionCreateEvent();
+    run: (client, interaction: CommandInteraction<TextChannel>) => {
+    return new NReaderEvent<CommandInteraction<TextChannel>, any, any, any>(client, interaction).interactionCreateEvent();
     }
 };

--- a/bot/src/NReader.ts
+++ b/bot/src/NReader.ts
@@ -1,13 +1,14 @@
 import { NReaderClient } from "nreader-framework/lib";
 import * as Config from "../../config/config.json";
 
-const client = new NReaderClient(Config.BOT.TOKEN, {
-    defaultImageFormat: "png",
-    intents: [
-        "guilds",
-    ],
-    maxShards: "auto"
-});
+const client = new NReaderClient({
+    auth: Config.BOT.TOKEN,
+    gateway: {
+        intents: ["GUILDS"],
+        maxShards: "auto"
+    },
+    defaultImageFormat: "png"
+})
 
 client.config = Config;
 client.initialiseEverything();

--- a/bot/src/NReader.ts
+++ b/bot/src/NReader.ts
@@ -3,11 +3,11 @@ import * as Config from "../../config/config.json";
 
 const client = new NReaderClient({
     auth: Config.BOT.TOKEN,
+    defaultImageFormat: "png",
     gateway: {
         intents: ["GUILDS"],
         maxShards: "auto"
-    },
-    defaultImageFormat: "png"
+    }
 });
 
 client.config = Config;

--- a/bot/src/NReader.ts
+++ b/bot/src/NReader.ts
@@ -8,7 +8,7 @@ const client = new NReaderClient({
         maxShards: "auto"
     },
     defaultImageFormat: "png"
-})
+});
 
 client.config = Config;
 client.initialiseEverything();

--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -1,11 +1,11 @@
 import { APIStats } from "./Utils/APIStats";
-import { Client, ClientEvents } from "eris";
+import { Client, ClientEvents } from "oceanic.js";
 import { Collection } from "./Utils";
 import { ICommand, IConfig, IEvent, IGuildSchemaSettings } from "./Interfaces";
 import { TLocale } from "./Types";
-import { Utils } from "givies-framework";
 import { connect } from "mongoose";
 import { GuildModel } from "./Models";
+import { Logger } from "./Utils/Logger";
 import { RequestHandler } from "./API";
 import { join } from "path";
 import { readdirSync } from "fs";
@@ -41,7 +41,7 @@ export class NReaderClient extends Client {
     /**
      * Logger
      */
-    public logger = new Utils.Logger();
+    public logger = new Logger();
 
     /**
      * NHentai API
@@ -65,7 +65,7 @@ export class NReaderClient extends Client {
 
             if (commands) {
                 commands.forEach((command) => {
-                    this.createCommand({
+                    this.rest.applicationCommands.createGlobalCommand(this.user.id, {
                         description: command.description,
                         name: command.name,
                         options: command.options,
@@ -91,10 +91,10 @@ export class NReaderClient extends Client {
             }
         });
 
-        this.editStatus("dnd", {
+        this.editStatus("dnd", [{
             name: "Reading...",
             type: 0
-        });
+        }]);
 
         const commandPath = join(__dirname, "..", "..", "bot", "src", "Commands");
         const eventPath = join(__dirname, "..", "..", "bot", "src", "Events");

--- a/framework/lib/Commands/Command.ts
+++ b/framework/lib/Commands/Command.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction, TextableChannel } from "eris";
+import { CommandInteraction, TextChannel } from "oceanic.js";
 import { NReaderClient } from "../Client";
 import { ICommandRunPayload } from "../Interfaces";
 import * as CommandModules from "./Modules";
@@ -11,9 +11,9 @@ export class NReaderCommand {
     private client: NReaderClient;
 
     /**
-     * Eris command interaction
+     * Oceanic command interaction
      */
-    private interaction: CommandInteraction<TextableChannel>;
+    private interaction: CommandInteraction<TextChannel>;
 
     constructor(payload: ICommandRunPayload) {
         this.client = payload.client;

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -7,15 +7,7 @@ import { createBookmarkPaginator } from "../../Modules/BookmarkPaginator";
 import { setTimeout } from "node:timers/promises";
 
 export async function bookmarkCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
-    const args: { user?: string } = {};
-
-    if (interaction.data.options) {
-        for (const option of interaction.data.options.raw) {
-            args[option.name] = (option as any).value;
-        }
-    }
-
-    const user = interaction.member.guild.members.get(args.user || interaction.member.id);
+    const user = interaction.data.options ? interaction.data.options.getUser("user") : interaction.member.user;
     const guildData = await UserModel.findOne({ id: user.id });
     const bookmarked = guildData.bookmark;
 

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -1,16 +1,16 @@
 import { NReaderClient } from "../../Client";
-import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
+import { MessageActionRow, CommandInteraction, Constants, TextChannel } from "oceanic.js";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { Gallery } from "../../API";
-import { Utils } from "givies-framework";
 import { UserModel } from "../../Models";
 import { createBookmarkPaginator } from "../../Modules/BookmarkPaginator";
 import { setTimeout } from "node:timers/promises";
 
-export async function bookmarkCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function bookmarkCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const args: { user?: string } = {};
 
     if (interaction.data.options) {
-        for (const option of interaction.data.options) {
+        for (const option of interaction.data.options.raw) {
             args[option.name] = (option as any).value;
         }
     }
@@ -21,13 +21,13 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
 
     if (user) {
         if (!bookmarked || bookmarked.length === 0) {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.bookmark.none", { user: user.username }))
                 .setTitle(client.translate("main.bookmark.title", { user: user.username }));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
                 flags: Constants.MessageFlags.EPHEMERAL
             });
         }
@@ -46,12 +46,12 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
                 title = await client.api.getGallery(bookmarked[i]).then((gallery) => `\`⬛ ${(i + 1).toString().length > 1 ? `${i + 1}` : `${i + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``);
                 gallery = await client.api.getGallery(bookmarked[i]);
             } catch (err) {
-                const embed = new Utils.RichEmbed()
+                const embed = new RichEmbed()
                     .setColor(client.config.BOT.COLOUR)
                     .setDescription(client.translate("main.error"));
 
                 return interaction.createMessage({
-                    embeds: [embed],
+                    embeds: [embed.data],
                 });
             }
 
@@ -59,16 +59,16 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
             bookmarkedTitle.push(title);
         }
 
-        const component: ActionRow = {
+        const component: MessageActionRow = {
             components: [
                 {
-                    custom_id: `see_more_${interaction.id}`,
+                    customID: `see_more_${interaction.id}`,
                     label: client.translate("main.detail"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_result_${interaction.id}`,
+                    customID: `stop_result_${interaction.id}`,
                     label: client.translate("main.stop"),
                     style: 4,
                     type: 2
@@ -77,23 +77,23 @@ export async function bookmarkCommand(client: NReaderClient, interaction: Comman
             type: 1
         };
 
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(bookmarkedTitle.join("\n"))
             .setTitle(client.translate("main.bookmark.title", { user: user.username }));
 
         createBookmarkPaginator(client, galleries, interaction, user);
-        return interaction.createMessage({
+        return interaction.createFollowup({
             components: [component],
-            embeds: [embed],
+            embeds: [embed.data],
         });
     } else {
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("main.error"));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
         });
     }
 }

--- a/framework/lib/Commands/Modules/ConfigCommand.ts
+++ b/framework/lib/Commands/Modules/ConfigCommand.ts
@@ -6,18 +6,14 @@ import { TLocale } from "../../Types";
 import { GuildModel } from "../../Models";
 
 export function configCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
-    const args: { language?: TLocale } = {};
+    const language = interaction.data.options.getString<TLocale>("language");
 
-    for (const option of (interaction.data.options[0] as InteractionOptionsSubCommand).options) {
-        args[(option as InteractionOptionsString).name] = (option as InteractionOptionsString).value;
-    }
-
-    if (args.language) {
-        GuildModel.findOneAndUpdate({ id: interaction.guildID }, { $set: { "settings.locale": args.language } }).exec();
+    if (language) {
+        GuildModel.findOneAndUpdate({ id: interaction.guildID }, { $set: { "settings.locale": language } }).exec();
 
         const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
-            .setDescription(client.translateLocale(args.language, "mod.language.set", { language: Util.convertLocale(args.language) }));
+            .setDescription(client.translateLocale(language, "mod.language.set", { language: Util.convertLocale(language) }));
 
         return interaction.createMessage({
             embeds: [embed.data],

--- a/framework/lib/Commands/Modules/ConfigCommand.ts
+++ b/framework/lib/Commands/Modules/ConfigCommand.ts
@@ -1,5 +1,5 @@
 import { NReaderClient } from "../../Client";
-import { CommandInteraction, Constants, InteractionOptionsString, InteractionOptionsSubCommand, TextChannel } from "oceanic.js";
+import { CommandInteraction, Constants, TextChannel } from "oceanic.js";
 import { RichEmbed } from "../../Utils/RichEmbed";
 import { Util } from "../../Utils";
 import { TLocale } from "../../Types";

--- a/framework/lib/Commands/Modules/ConfigCommand.ts
+++ b/framework/lib/Commands/Modules/ConfigCommand.ts
@@ -1,26 +1,26 @@
 import { NReaderClient } from "../../Client";
-import { CommandInteraction, Constants, InteractionDataOptionsString, InteractionDataOptionsSubCommand, TextableChannel } from "eris";
-import { Utils } from "givies-framework";
+import { CommandInteraction, Constants, InteractionOptionsString, InteractionOptionsSubCommand, TextChannel } from "oceanic.js";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { Util } from "../../Utils";
 import { TLocale } from "../../Types";
 import { GuildModel } from "../../Models";
 
-export function configCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export function configCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const args: { language?: TLocale } = {};
 
-    for (const option of (interaction.data.options[0] as InteractionDataOptionsSubCommand).options) {
-        args[(option as InteractionDataOptionsString).name] = (option as InteractionDataOptionsString).value;
+    for (const option of (interaction.data.options[0] as InteractionOptionsSubCommand).options) {
+        args[(option as InteractionOptionsString).name] = (option as InteractionOptionsString).value;
     }
 
     if (args.language) {
         GuildModel.findOneAndUpdate({ id: interaction.guildID }, { $set: { "settings.locale": args.language } }).exec();
 
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translateLocale(args.language, "mod.language.set", { language: Util.convertLocale(args.language) }));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }

--- a/framework/lib/Commands/Modules/HelpCommand.ts
+++ b/framework/lib/Commands/Modules/HelpCommand.ts
@@ -4,7 +4,7 @@ import { RichEmbed } from "../../Utils/RichEmbed";
 import { NReaderConstant } from "../../Constant";
 
 export function helpCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
-    if ((interaction.channel as TextChannel).nsfw) {
+    if (interaction.channel.nsfw) {
         const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("general.help.description", { server: "https://discord.gg/b7AW2Zkcsw", user: interaction.member.username }))

--- a/framework/lib/Commands/Modules/HelpCommand.ts
+++ b/framework/lib/Commands/Modules/HelpCommand.ts
@@ -1,11 +1,11 @@
-import { CommandInteraction, Constants, TextableChannel, TextChannel } from "eris";
+import { CommandInteraction, Constants, TextChannel } from "oceanic.js";
 import { NReaderClient } from "../../Client";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { NReaderConstant } from "../../Constant";
 
-export function helpCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export function helpCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     if ((interaction.channel as TextChannel).nsfw) {
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("general.help.description", { server: "https://discord.gg/b7AW2Zkcsw", user: interaction.member.username }))
             .addField(client.translate("general.help.usage.name"), client.translate("general.help.usage.value", { bot: client.user.username, doujin: `[nhentai.net](${NReaderConstant.Source.BASE})` }))
@@ -13,16 +13,16 @@ export function helpCommand(client: NReaderClient, interaction: CommandInteracti
             .setTitle(client.translate("general.help.title"));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
         });
     } else {
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("general.help.nsfw"))
             .setTitle(client.translate("general.help.title"));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }

--- a/framework/lib/Commands/Modules/PingCommand.ts
+++ b/framework/lib/Commands/Modules/PingCommand.ts
@@ -1,14 +1,14 @@
-import { CommandInteraction, Constants, TextableChannel } from "eris";
-import { Utils } from "givies-framework";
+import { CommandInteraction, Constants, TextChannel } from "oceanic.js";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { NReaderClient } from "../../Client";
 
-export function pingCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
-    const embed = new Utils.RichEmbed()
+export function pingCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
+    const embed = new RichEmbed()
         .setColor(client.config.BOT.COLOUR)
         .setDescription(client.translate("general.ping", { latency: interaction.member.guild.shard.latency.toString() }));
 
     return interaction.createMessage({
-        embeds: [embed],
+        embeds: [embed.data],
         flags: Constants.MessageFlags.EPHEMERAL
     });
 }

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -1,14 +1,15 @@
 import { NReaderClient } from "../../Client";
-import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
+import { MessageActionRow, CommandInteraction, Constants, TextChannel } from "oceanic.js";
+import { Util } from "../../Utils";
 import { GuildModel } from "../../Models";
 import { createReadPaginator } from "../../Modules/ReadPaginator";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { setTimeout } from "node:timers/promises";
 
-export async function readCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function readCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const args: { id?: number } = {};
 
-    for (const option of interaction.data.options) {
+    for (const option of interaction.data.options.raw) {
         args[option.name] = (option as any).value as string;
     }
 
@@ -25,18 +26,18 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
         const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
         const tags = gallery.tags.tags.map((tag) => tag.name);
 
-        if (Utils.Util.findCommonElement(tags, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
-            const embed = new Utils.RichEmbed()
+        if (Util.findCommonElement(tags, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.tags.restricted", { channel: "[#info](https://discord.com/channels/763678230976659466/1005030227174490214)", server: "https://discord.gg/b7AW2Zkcsw" }));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
                 flags: Constants.MessageFlags.EPHEMERAL
             });
         }
 
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setAuthor(gallery.id, gallery.url)
             .setColor(client.config.BOT.COLOUR)
             .addField(client.translate("main.title"), `\`${gallery.title.pretty}\``)
@@ -50,28 +51,28 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
             .setFooter(`⭐ ${gallery.favourites.toLocaleString()}`)
             .setThumbnail(gallery.cover.url);
 
-        const component: ActionRow = {
+        const component: MessageActionRow = {
             components: [
                 {
-                    custom_id: `read_${interaction.id}`,
+                    customID: `read_${interaction.id}`,
                     label: client.translate("main.read"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_${interaction.id}`,
+                    customID: `stop_${interaction.id}`,
                     label: client.translate("main.stop"),
                     style: 4,
                     type: 2
                 },
                 {
-                    custom_id: `bookmark_${interaction.id}`,
+                    customID: `bookmark_${interaction.id}`,
                     label: client.translate("main.bookmark"),
                     style: 2,
                     type: 2
                 },
                 {
-                    custom_id: `show_cover_${interaction.id}`,
+                    customID: `show_cover_${interaction.id}`,
                     label: client.translate("main.cover.show"),
                     style: 1,
                     type: 2
@@ -80,24 +81,24 @@ export async function readCommand(client: NReaderClient, interaction: CommandInt
             type: 1
         };
 
-        interaction.createMessage({ components: [component], embeds: [embed] });
+        interaction.createFollowup({ components: [component], embeds: [embed.data] });
         createReadPaginator(client, gallery, interaction);
     }).catch((err: Error) => {
         if (err.message === "Request failed with status code 404") {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.read.none", { id: args.id }));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         } else {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.error"));
 
             interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         }
 

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -1,28 +1,29 @@
 import { Constant } from "../../API";
 import { NReaderClient } from "../../Client";
-import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { Utils } from "givies-framework";
+import { MessageActionRow, CommandInteraction, Constants, TextChannel } from "oceanic.js";
+import { RichEmbed } from "../../Utils/RichEmbed";
+import { Util } from "../../Utils";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 
-export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const args: { page?: number, query?: string, sort?: Constant.TSearchSort } = {};
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
 
-    for (const option of interaction.data.options) {
+    for (const option of interaction.data.options.raw) {
         args[option.name] = (option as any).value as string;
     }
 
     const queryArgs = args.query.split(" ");
 
-    if (Utils.Util.findCommonElement(queryArgs, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
-        const embed = new Utils.RichEmbed()
+    if (Util.findCommonElement(queryArgs, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("main.tags.restricted", { channel: "[#info](https://discord.com/channels/763678230976659466/1005030227174490214)", server: "https://discord.gg/b7AW2Zkcsw" }));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }
@@ -32,32 +33,32 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
 
     client.api.searchGalleries(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1, args.sort || "").then(async (search) => {
         if (search.result.length === 0) {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.search.none", { query: args.query }));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         }
 
         const title = search.result.map((gallery, index) => `\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}`  : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``);
 
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(title.join("\n"))
             .setTitle(client.translate("main.page", { firstIndex: search.page, lastIndex: search.numPages.toLocaleString() }));
 
-        const component: ActionRow = {
+        const component: MessageActionRow = {
             components: [
                 {
-                    custom_id: `see_more_${interaction.id}`,
+                    customID: `see_more_${interaction.id}`,
                     label: client.translate("main.detail"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_result_${interaction.id}`,
+                    customID: `stop_result_${interaction.id}`,
                     label: client.translate("main.stop"),
                     style: 4,
                     type: 2
@@ -67,18 +68,18 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
         };
 
         createSearchPaginator(client, search, interaction);
-        interaction.createMessage({
+        interaction.createFollowup({
             components: [component],
-            embeds: [embed]
+            embeds: [embed.data]
         });
     }).catch((err: Error) => {
         if (err) {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.error"));
 
             interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         }
 

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -8,14 +8,12 @@ import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 
 export async function searchCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
-    const args: { page?: number, query?: string, sort?: Constant.TSearchSort } = {};
+    const page = interaction.data.options.getInteger("page");
+    const query = interaction.data.options.getString("query");
+    const sort = interaction.data.options.getString<Constant.TSearchSort>("sort");
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
 
-    for (const option of interaction.data.options.raw) {
-        args[option.name] = (option as any).value as string;
-    }
-
-    const queryArgs = args.query.split(" ");
+    const queryArgs = query.split(" ");
 
     if (Util.findCommonElement(queryArgs, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
         const embed = new RichEmbed()
@@ -31,11 +29,11 @@ export async function searchCommand(client: NReaderClient, interaction: CommandI
     await interaction.defer();
     await setTimeout(2000);
 
-    client.api.searchGalleries(encodeURIComponent(guildData.settings.whitelisted ? args.query : `${args.query} -lolicon -shotacon`), args.page || 1, args.sort || "").then(async (search) => {
+    client.api.searchGalleries(encodeURIComponent(guildData.settings.whitelisted ? query : `${query} -lolicon -shotacon`), page || 1, sort || "").then(async (search) => {
         if (search.result.length === 0) {
             const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
-                .setDescription(client.translate("main.search.none", { query: args.query }));
+                .setDescription(client.translate("main.search.none", { query: query }));
 
             return interaction.createMessage({
                 embeds: [embed.data],

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -69,13 +69,13 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
             embeds: [embed.data]
         });
     }).catch((err: Error) => {
-            const embed = new RichEmbed()
-                .setColor(client.config.BOT.COLOUR)
-                .setDescription(client.translate("main.error"));
+        const embed = new RichEmbed()
+            .setColor(client.config.BOT.COLOUR)
+            .setDescription(client.translate("main.error"));
 
-            interaction.createFollowup({
-                embeds: [embed.data],
-            });
+        interaction.createFollowup({
+            embeds: [embed.data],
+        });
 
         return client.logger.error({ message: err.message, subTitle: "NHentaiAPI::SearchALike", title: "API" });
     });

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -1,28 +1,29 @@
 import { NReaderClient } from "../../Client";
-import { ActionRow, CommandInteraction, Constants, TextableChannel } from "eris";
-import { Utils } from "givies-framework";
+import { MessageActionRow, CommandInteraction, Constants, TextChannel } from "oceanic.js";
+import { RichEmbed } from "../../Utils/RichEmbed";
+import { Util } from "../../Utils";
 import { createSearchPaginator } from "../../Modules/SearchPaginator";
 import { GuildModel } from "../../Models";
 import { setTimeout } from "node:timers/promises";
 
-export async function searchSimilarCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function searchSimilarCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const args: { id?: number } = {};
     const guildData = await GuildModel.findOne({ id: interaction.guildID });
 
-    for (const option of interaction.data.options) {
+    for (const option of interaction.data.options.raw) {
         args[option.name] = (option as any).value as string;
     }
 
     const gallery = await client.api.getGallery(args.id.toString());
     const tags = gallery.tags.tags.map((tag) => tag.name);
 
-    if (Utils.Util.findCommonElement(tags, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
-        const embed = new Utils.RichEmbed()
+    if (Util.findCommonElement(tags, client.config.API.RESTRICTED_TAGS) && !guildData.settings.whitelisted) {
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("main.tags.restricted", { channel: "[#info](https://discord.com/channels/763678230976659466/1005030227174490214)", server: "https://discord.gg/b7AW2Zkcsw" }));
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }
@@ -32,32 +33,32 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
 
     client.api.getGalleryRelated(args.id.toString()).then(async (search) => {
         if (search.result.length === 0) {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.search.empty"));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         }
 
         const title = search.result.map((gallery, index) => `\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}`  : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty}\``);
 
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(title.join("\n"))
             .setTitle(client.translate("main.page", { firstIndex: search.page, lastIndex: search.numPages.toLocaleString() }));
 
-        const component: ActionRow = {
+        const component: MessageActionRow = {
             components: [
                 {
-                    custom_id: `see_more_${interaction.id}`,
+                    customID: `see_more_${interaction.id}`,
                     label: client.translate("main.detail"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_result_${interaction.id}`,
+                    customID: `stop_result_${interaction.id}`,
                     label: client.translate("main.stop"),
                     style: 4,
                     type: 2
@@ -67,26 +68,26 @@ export async function searchSimilarCommand(client: NReaderClient, interaction: C
         };
 
         createSearchPaginator(client, search, interaction);
-        interaction.createMessage({
+        interaction.createFollowup({
             components: [component],
-            embeds: [embed]
+            embeds: [embed.data]
         });
     }).catch((err: Error) => {
         if (err.message === "Request failed with status code 404") {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.read.none", { id: args.id }));
 
             return interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         } else {
-            const embed = new Utils.RichEmbed()
+            const embed = new RichEmbed()
                 .setColor(client.config.BOT.COLOUR)
                 .setDescription(client.translate("main.error"));
 
             interaction.createMessage({
-                embeds: [embed],
+                embeds: [embed.data],
             });
         }
 

--- a/framework/lib/Commands/Modules/StatsCommand.ts
+++ b/framework/lib/Commands/Modules/StatsCommand.ts
@@ -31,13 +31,13 @@ export async function statsCommand(client: NReaderClient, interaction: CommandIn
             .addField(client.translate("general.stats.cpu"), `${Util.round(percentage, 2)}%`, true)
             .addField(client.translate("general.stats.uptime"), `${Util.time(client.uptime)}`, true)
             .addField("NodeJS", `${process.versions.node}`, true)
-            .addField("Eris", `${VERSION}`, true)
+            .addField("Oceanic", `${VERSION}`, true)
             .addField("API", API_VERSION, true)
             .addField(client.translate("general.stats.server"), `${guildData.length.toLocaleString()} (${client.guilds.size.toLocaleString()})`, true)
             .addField(client.translate("general.stats.user"), `${userData.length.toLocaleString()} (${client.users.size.toLocaleString()})`, true)
             .addField(client.translate("general.stats.platform"), `${process.platform.charAt(0).toUpperCase() + process.platform.slice(1)}`, true);
 
-        return interaction.createMessage({
+        return interaction.createFollowup({
             embeds: [embed.data]
         });
     });

--- a/framework/lib/Commands/Modules/StatsCommand.ts
+++ b/framework/lib/Commands/Modules/StatsCommand.ts
@@ -1,14 +1,14 @@
 import { NReaderClient } from "../../Client";
-import { CommandInteraction, TextableChannel, VERSION } from "eris";
+import { CommandInteraction, TextChannel, VERSION } from "oceanic.js";
 import { GuildModel, UserModel } from "../../Models";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../../Utils/RichEmbed";
 import { Util } from "../../Utils";
 import osUtils from "os-utils";
 import os from "os";
 import { setTimeout } from "node:timers/promises";
 import { API_VERSION } from "../../API";
 
-export async function statsCommand(client: NReaderClient, interaction: CommandInteraction<TextableChannel>) {
+export async function statsCommand(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     const memory: number = process.memoryUsage().rss;
 
     await interaction.defer();
@@ -21,10 +21,10 @@ export async function statsCommand(client: NReaderClient, interaction: CommandIn
     const userData = await UserModel.find({});
 
     osUtils.cpuUsage((percentage) => {
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
-            .setFooter(client.user.username, client.user.avatarURL)
-            .setThumbnail(client.user.avatarURL)
+            .setFooter(client.user.username, client.user.avatarURL("png"))
+            .setThumbnail(client.user.avatarURL("png"))
             .setTimestamp()
             .setTitle(client.translate("general.stats.title").replace("{bot}", client.user.username))
             .addField(client.translate("general.stats.memory"), `${totalMemory} \n (${Math.round(used * 100) / 100}%)`, true)
@@ -38,7 +38,7 @@ export async function statsCommand(client: NReaderClient, interaction: CommandIn
             .addField(client.translate("general.stats.platform"), `${process.platform.charAt(0).toUpperCase() + process.platform.slice(1)}`, true);
 
         return interaction.createMessage({
-            embeds: [embed]
+            embeds: [embed.data]
         });
     });
 }

--- a/framework/lib/Events/Modules/ErrorEvent.ts
+++ b/framework/lib/Events/Modules/ErrorEvent.ts
@@ -1,10 +1,10 @@
 import { NReaderClient } from "../../Client";
-import { Utils } from "givies-framework";
+import { Logger } from "../../Utils/Logger";
 
 export function errorEvent(client: NReaderClient, err: string, id: number) {
     client.logger.error({ message: err, subTitle: "NReaderFramework::Events::Error", title: `SHARD ${id}` });
 }
 
 export function tsError(err: string) {
-    new Utils.Logger().error({ message: err, subTitle: "TypeScript::Error", title: "UNHANDLED REJECTION" });
+    new Logger().error({ message: err, subTitle: "TypeScript::Error", title: "UNHANDLED REJECTION" });
 }

--- a/framework/lib/Events/Modules/GuildCreateEvent.ts
+++ b/framework/lib/Events/Modules/GuildCreateEvent.ts
@@ -1,5 +1,5 @@
 import { NReaderClient } from "../../Client";
-import { Guild } from "eris";
+import { Guild } from "oceanic.js";
 import { GuildModel } from "../../Models";
 import { IGuildSchemaSettings } from "../../Interfaces";
 

--- a/framework/lib/Events/Modules/GuildDeleteEvent.ts
+++ b/framework/lib/Events/Modules/GuildDeleteEvent.ts
@@ -1,5 +1,5 @@
 import { NReaderClient } from "../../Client";
-import { Guild } from "eris";
+import { Guild } from "oceanic.js";
 
 export function guildDeleteEvent(client: NReaderClient, guild: Guild) {
     client.logger.info({ message: `Guild ${guild.name} (${guild.id}) Has Left`, subTitle: "NReaderFramework::Events::GuildDelete", title: "GUILDS" });

--- a/framework/lib/Events/Modules/InteractionCreateEvent.ts
+++ b/framework/lib/Events/Modules/InteractionCreateEvent.ts
@@ -1,9 +1,9 @@
 import { NReaderClient } from "../../Client";
-import { CommandInteraction, Constants, TextChannel } from "eris";
+import { CommandInteraction, Constants, TextChannel } from "oceanic.js";
 import { t } from "i18next";
 import { GuildModel, UserModel } from "../../Models";
-import { Utils } from "givies-framework";
 import { Util } from "../../Utils";
+import { RichEmbed } from "../../Utils/RichEmbed";
 
 export async function interactionCreateEvent(client: NReaderClient, interaction: CommandInteraction<TextChannel>) {
     if (!interaction.guildID) return;
@@ -23,7 +23,7 @@ export async function interactionCreateEvent(client: NReaderClient, interaction:
     };
 
     if (!userData) {
-        const embed = new Utils.RichEmbed()
+        const embed = new RichEmbed()
             .setColor(client.config.BOT.COLOUR)
             .setDescription(client.translate("general.register"));
 
@@ -37,7 +37,7 @@ export async function interactionCreateEvent(client: NReaderClient, interaction:
         });
 
         return interaction.createMessage({
-            embeds: [embed],
+            embeds: [embed.data],
             flags: Constants.MessageFlags.EPHEMERAL
         });
     }

--- a/framework/lib/Interfaces/ICommand.ts
+++ b/framework/lib/Interfaces/ICommand.ts
@@ -1,9 +1,9 @@
 import { NReaderClient } from "../Client";
-import { ApplicationCommandTypes, ApplicationCommandOptions, CommandInteraction, TextableChannel } from "eris";
+import { ApplicationCommandTypes, ApplicationCommandOptions, CommandInteraction, TextChannel } from "oceanic.js";
 
 export interface ICommandRunPayload {
     client: NReaderClient;
-    interaction: CommandInteraction<TextableChannel>;
+    interaction: CommandInteraction<TextChannel>;
 }
 
 export interface  ICommandRun {

--- a/framework/lib/Interfaces/IEvent.ts
+++ b/framework/lib/Interfaces/IEvent.ts
@@ -1,5 +1,5 @@
 import { NReaderClient } from "../Client";
-import { ClientEvents } from "eris";
+import { ClientEvents } from "oceanic.js";
 
 export interface IEventRun {
     (client: NReaderClient, ...args: any);

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -144,7 +144,7 @@ export class BookmarkPaginator {
 
     /**
      * Start searching
-     * @param interaction Eris component interaction
+     * @param interaction Oceanic component interaction
      */
     public async onSearch(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -1,5 +1,5 @@
 import { RequestHandler, Gallery } from "../API";
-import { CommandInteraction, ComponentInteraction, Constants, EmbedOptions, InteractionContent, Member, MessageActionRow, Message, ModalSubmitInteraction, TextChannel } from "oceanic.js";
+import { CommandInteraction, ComponentInteraction, Constants, EmbedOptions, InteractionContent, MessageActionRow, Message, ModalSubmitInteraction, TextChannel, User } from "oceanic.js";
 import { NReaderClient } from "../Client";
 import { RichEmbed } from "../Utils/RichEmbed";
 import { UserModel } from "../Models";
@@ -56,7 +56,7 @@ export class BookmarkPaginator {
     /**
      * The user who owned the bookmark
      */
-    user: Member;
+    user: User;
 
     /**
      * Creates a read paginator
@@ -64,7 +64,7 @@ export class BookmarkPaginator {
      * @param galleries Current galleries
      * @param interaction Oceanic command interaction
      */
-    constructor(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: Member) {
+    constructor(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: User) {
         this.api = client.api;
         this.client = client;
         this.embed = 1;
@@ -442,7 +442,7 @@ export class BookmarkPaginator {
     }
 }
 
-export async function createBookmarkPaginator(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: Member) {
+export async function createBookmarkPaginator(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: User) {
     const paginator = new BookmarkPaginator(client, galleries, interaction, user);
 
     paginator.runPaginator();

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -1,7 +1,7 @@
 import { RequestHandler, Gallery } from "../API";
-import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Member, Message, ModalSubmitInteraction, TextableChannel } from "eris";
+import { CommandInteraction, ComponentInteraction, Constants, EmbedOptions, InteractionContent, Member, MessageActionRow, Message, ModalSubmitInteraction, TextChannel } from "oceanic.js";
 import { NReaderClient } from "../Client";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../Utils/RichEmbed";
 import { UserModel } from "../Models";
 import { ReadSearchPaginator } from "./ReadSearchPaginator";
 import { NReaderConstant } from "../Constant";
@@ -34,14 +34,14 @@ export class BookmarkPaginator {
     galleries: Gallery[];
 
     /**
-     * Eris command interaction
+     * Oceanic command interaction
      */
-    interaction: CommandInteraction<TextableChannel>;
+    interaction: CommandInteraction<TextChannel>;
 
     /**
      * The message for embed pages
      */
-    message: Message<TextableChannel>;
+    message: Message<TextChannel>;
 
     /**
      * The read paginator
@@ -62,9 +62,9 @@ export class BookmarkPaginator {
      * Creates a read paginator
      * @param client NReader client
      * @param galleries Current galleries
-     * @param interaction Eris command interaction
+     * @param interaction Oceanic command interaction
      */
-    constructor(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextableChannel>, user: Member) {
+    constructor(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: Member) {
         this.api = client.api;
         this.client = client;
         this.embed = 1;
@@ -89,7 +89,7 @@ export class BookmarkPaginator {
             const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-            return new Utils.RichEmbed()
+            return new RichEmbed()
                 .setAuthor(gallery.id, gallery.url)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty}\`**`))
@@ -106,31 +106,31 @@ export class BookmarkPaginator {
                 .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
         });
 
-        this.embeds = embeds;
+        this.embeds = embeds.map((embed) => embed.data);
 
-        const messageContent: AdvancedMessageContent = {
+        const messageContent: InteractionContent = {
             components: [
                 {
                     components: [
-                        { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                        { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                        { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                        { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                        { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                        { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -138,7 +138,7 @@ export class BookmarkPaginator {
             embeds: [this.embeds[this.embed - 1]]
         };
 
-        this.message = await this.interaction.editOriginalMessage(messageContent);
+        this.message = await this.interaction.editOriginal(messageContent);
         this.updatePaginator();
     }
 
@@ -146,70 +146,70 @@ export class BookmarkPaginator {
      * Start searching
      * @param interaction Eris component interaction
      */
-    public async onSearch(interaction: ComponentInteraction<TextableChannel> | ModalSubmitInteraction<TextableChannel>) {
+    public async onSearch(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;
 
-        const embed = new Utils.RichEmbed((interaction as ComponentInteraction).message ? (interaction as ComponentInteraction).message.embeds[0] : undefined);
+        const embed = new RichEmbed((interaction as ComponentInteraction).message ? (interaction as ComponentInteraction).message.embeds[0] : undefined);
         const userData = await UserModel.findOne({ id: interaction.member.id });
 
-        const hideComponent: ActionRow[] = [
+        const hideComponent: MessageActionRow[] = [
             {
                 components: [
-                    { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                    { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                    { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                    { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                    { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                    { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                    { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                    { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                    { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                    { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                    { custom_id: `hide_cover_${this.interaction.id}`, label: this.client.translate("main.cover.hide"), style: 1, type: 2 }
+                    { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                    { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                    { customID: `hide_cover_${this.interaction.id}`, label: this.client.translate("main.cover.hide"), style: 1, type: 2 }
                 ],
                 type: 1
             }
         ];
 
-        const showComponent: ActionRow[] = [
+        const showComponent: MessageActionRow[] = [
             {
                 components: [
-                    { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                    { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                    { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                    { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                    { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                    { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                    { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                    { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                    { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                    { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                    { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                    { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                    { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                    { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                 ],
                 type: 1
             }
         ];
 
         if (interaction instanceof ComponentInteraction) {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `read_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.api.getGallery(embed.author.name).then(async (gallery) => {
                         this.paginationEmbed = new ReadSearchPaginator(this.client, gallery, this.interaction);
@@ -219,27 +219,27 @@ export class BookmarkPaginator {
 
                     break;
                 case `see_more_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     this.initialisePaginator();
                     break;
                 case `show_cover_${this.interaction.id}`:
                     embed.setImage((await this.api.getGallery(embed.author.name)).cover.url);
-                    this.interaction.editOriginalMessage({ components: hideComponent, embeds: [embed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: hideComponent, embeds: [embed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `hide_cover_${this.interaction.id}`:
                     embed.setImage("");
-                    this.interaction.editOriginalMessage({ components: showComponent, embeds: [embed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: showComponent, embeds: [embed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `home_result_${this.interaction.id}`:
-                    this.interaction.editOriginalMessage({ components: showComponent, embeds: [this.embeds[this.embed - 1]] });
+                    this.interaction.editOriginal({ components: showComponent, embeds: [this.embeds[this.embed - 1]] });
                     this.paginationEmbed.stopPaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
                 case `stop_result_${this.interaction.id}`:
                     interaction.message.delete();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     this.stopPaginator();
 
                     try {
@@ -257,9 +257,9 @@ export class BookmarkPaginator {
                     if (userData.bookmark.includes(embed.author.name)) {
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -269,9 +269,9 @@ export class BookmarkPaginator {
                         if (userData.bookmark.length === 25) {
                             return interaction.createMessage({
                                 embeds: [
-                                    new Utils.RichEmbed()
+                                    new RichEmbed()
                                         .setColor(this.client.config.BOT.COLOUR)
-                                        .setDescription(this.client.translate("main.bookmark.maxed"))
+                                        .setDescription(this.client.translate("main.bookmark.maxed")).data
                                 ],
                                 flags: Constants.MessageFlags.EPHEMERAL
                             });
@@ -279,9 +279,9 @@ export class BookmarkPaginator {
 
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -291,7 +291,7 @@ export class BookmarkPaginator {
 
                     break;
                 case `next_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed < this.embeds.length) {
                         this.embed++;
@@ -300,7 +300,7 @@ export class BookmarkPaginator {
 
                     break;
                 case `previous_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed > 1) {
                         this.embed--;
@@ -309,45 +309,42 @@ export class BookmarkPaginator {
 
                     break;
                 case `first_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = 1;
                     this.updatePaginator();
                     break;
                 case `last_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = this.embeds.length;
                     this.updatePaginator();
                     break;
                 case `jumpto_result_${this.interaction.id}`:
-                    this.client.createInteractionResponse(interaction.id, interaction.token, {
-                        data: ({
-                            components: [
-                                {
-                                    components: [
-                                        {
-                                            custom_id: "result_number",
-                                            label: this.client.translate("main.result.enter"),
-                                            placeholder: "10",
-                                            required: true,
-                                            style: 1,
-                                            type: 4
-                                        }
-                                    ],
-                                    type: 1
-                                }
-                            ],
-                            custom_id: `jumpto_result_modal_${this.interaction.id}`,
-                            title: this.client.translate("main.result.enter")
-                        } as any),
-                        type: Constants.InteractionResponseTypes.MODAL as any
+                    interaction.createModal({
+                        components: [
+                            {
+                                components: [
+                                    {
+                                        customID: "result_number",
+                                        label: this.client.translate("main.result.enter"),
+                                        placeholder: "10",
+                                        required: true,
+                                        style: 1,
+                                        type: 4
+                                    }
+                                ],
+                                type: 1
+                            }
+                        ],
+                        customID: `jumpto_result_modal_${this.interaction.id}`,
+                        title: this.client.translate("main.result.enter")
                     });
 
                     break;
             }
         } else {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `jumpto_result_modal_${this.interaction.id}`:
                     /* eslint-disable-next-line */
                     const page = parseInt(Util.getModalID(interaction, "result_number"));
@@ -355,9 +352,9 @@ export class BookmarkPaginator {
                     if (isNaN(page)) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.invalid"))
+                                    .setDescription(this.client.translate("main.result.enter.invalid")).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -366,9 +363,9 @@ export class BookmarkPaginator {
                     if (page > this.embeds.length) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -377,9 +374,9 @@ export class BookmarkPaginator {
                     if (page <= 0) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -387,7 +384,7 @@ export class BookmarkPaginator {
 
                     this.embed = page;
                     this.updatePaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
             }
         }
@@ -401,25 +398,25 @@ export class BookmarkPaginator {
             components: [
                 {
                     components: [
-                        { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                        { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                        { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                        { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                        { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                        { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -445,7 +442,7 @@ export class BookmarkPaginator {
     }
 }
 
-export async function createBookmarkPaginator(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextableChannel>, user: Member) {
+export async function createBookmarkPaginator(client: NReaderClient, galleries: Gallery[], interaction: CommandInteraction<TextChannel>, user: Member) {
     const paginator = new BookmarkPaginator(client, galleries, interaction, user);
 
     paginator.runPaginator();

--- a/framework/lib/Modules/LocalisationCompiler.ts
+++ b/framework/lib/Modules/LocalisationCompiler.ts
@@ -1,8 +1,8 @@
 import { join } from "path";
 import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from "fs";
-import { Utils } from "givies-framework";
+import { Logger } from "../Utils/Logger";
 
-const logger = new Utils.Logger();
+const logger = new Logger();
 const folders = readdirSync(join(__dirname, "../../../localisation"));
 const compilingDate = new Date();
 

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -100,7 +100,7 @@ export class ReadPaginator {
 
     /**
      * Start reading
-     * @param interaction Eris component interaction
+     * @param interaction Oceanic component interaction
      */
     public async onRead(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -1,7 +1,7 @@
 import { Gallery } from "../API";
-import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Message, ModalSubmitInteraction, TextableChannel } from "eris";
+import { CommandInteraction, ComponentInteraction, Constants, EmbedOptions, InteractionContent, MessageActionRow, Message, ModalSubmitInteraction, TextChannel } from "oceanic.js";
 import { NReaderClient } from "../Client";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../Utils/RichEmbed";
 import { UserModel } from "../Models";
 import { NReaderConstant } from "../Constant";
 import { Util } from "../Utils";
@@ -29,14 +29,14 @@ export class ReadSearchPaginator {
     gallery: Gallery;
 
     /**
-     * Eris command interaction
+     * Oceanic command interaction
      */
-    interaction: CommandInteraction<TextableChannel>;
+    interaction: CommandInteraction<TextChannel>;
 
     /**
      * The message for embed pages
      */
-    message: Message<TextableChannel>;
+    message: Message<TextChannel>;
 
     /**
      * Whether the paginator is running or not
@@ -47,19 +47,19 @@ export class ReadSearchPaginator {
      * Creates a read paginator
      * @param client NReader client
      * @param gallery Current NHentai gallery
-     * @param interaction Eris command interaction
+     * @param interaction Oceanic command interaction
      */
-    constructor(client: NReaderClient, gallery: Gallery, interaction: CommandInteraction<TextableChannel>) {
+    constructor(client: NReaderClient, gallery: Gallery, interaction: CommandInteraction<TextChannel>) {
         this.client = client;
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
-            return new Utils.RichEmbed()
+            return new RichEmbed()
                 .setAuthor(gallery.id, page.url)
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(client.translate("main.page", { firstIndex: index + 1, lastIndex: gallery.pages.length }))
                 .setImage(page.url)
                 .setTitle(gallery.title.pretty)
-                .setURL(gallery.url);
+                .setURL(gallery.url).data;
         });
         this.gallery = gallery;
         this.interaction = interaction;
@@ -71,23 +71,23 @@ export class ReadSearchPaginator {
      * Initialise the paginator class
      */
     public async initialisePaginator() {
-        const messageContent: AdvancedMessageContent = {
+        const messageContent: InteractionContent = {
             components: [
                 {
                     components: [
-                        { custom_id: `first_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                        { custom_id: `previous_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                        { custom_id: `last_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                        { customID: `first_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                        { customID: `previous_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                        { customID: `last_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `home_result_${this.interaction.id}`, label: this.client.translate("main.home"), style: 1, type: 2 }
+                        { customID: `jumpto_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `home_result_${this.interaction.id}`, label: this.client.translate("main.home"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -95,7 +95,7 @@ export class ReadSearchPaginator {
             embeds: [this.embeds[this.embed - 1]]
         };
 
-        this.message = await this.interaction.editOriginalMessage(messageContent);
+        this.message = await this.interaction.editOriginal(messageContent);
     }
 
     /**
@@ -106,19 +106,19 @@ export class ReadSearchPaginator {
             components: [
                 {
                     components: [
-                        { custom_id: `first_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                        { custom_id: `previous_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                        { custom_id: `last_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                        { customID: `first_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                        { customID: `previous_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                        { customID: `last_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `home_result_${this.interaction.id}`, label: this.client.translate("main.home"), style: 1, type: 2 }
+                        { customID: `jumpto_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `home_result_${this.interaction.id}`, label: this.client.translate("main.home"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -131,7 +131,7 @@ export class ReadSearchPaginator {
      * Start reading
      * @param interaction Eris component interaction
      */
-    public async onRead(interaction: ComponentInteraction<TextableChannel> | ModalSubmitInteraction<TextableChannel>) {
+    public async onRead(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;
 
         const userData = await UserModel.findOne({ id: interaction.member.id });
@@ -142,7 +142,7 @@ export class ReadSearchPaginator {
         const parodyTags: string[] = this.gallery.tags.parodies.map((tag) => tag.name);
         const uploadedAt = `<t:${this.gallery.uploadDate.getTime() / 1000}:F>`;
 
-        const resultEmbed = new Utils.RichEmbed()
+        const resultEmbed = new RichEmbed()
             .setAuthor(this.gallery.id, this.gallery.url)
             .setColor(this.client.config.BOT.COLOUR)
             .addField(this.client.translate("main.title"), `\`${this.gallery.title.pretty}\``)
@@ -156,28 +156,28 @@ export class ReadSearchPaginator {
             .setFooter(`⭐ ${this.gallery.favourites.toLocaleString()}`)
             .setThumbnail(this.gallery.cover.url);
 
-        const hideComponent: ActionRow = {
+        const hideComponent: MessageActionRow = {
             components: [
                 {
-                    custom_id: `read_${this.interaction.id}`,
+                    customID: `read_${this.interaction.id}`,
                     label: this.client.translate("main.read"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_${this.interaction.id}`,
+                    customID: `stop_${this.interaction.id}`,
                     label: this.client.translate("main.stop"),
                     style: 4,
                     type: 2
                 },
                 {
-                    custom_id: `bookmark_${this.interaction.id}`,
+                    customID: `bookmark_${this.interaction.id}`,
                     label: this.client.translate("main.bookmark"),
                     style: 2,
                     type: 2
                 },
                 {
-                    custom_id: `hide_cover_${this.interaction.id}`,
+                    customID: `hide_cover_${this.interaction.id}`,
                     label: this.client.translate("main.cover.hide"),
                     style: 1,
                     type: 2
@@ -186,28 +186,28 @@ export class ReadSearchPaginator {
             type: 1
         };
 
-        const showComponent: ActionRow = {
+        const showComponent: MessageActionRow = {
             components: [
                 {
-                    custom_id: `read_${this.interaction.id}`,
+                    customID: `read_${this.interaction.id}`,
                     label: this.client.translate("main.read"),
                     style: 1,
                     type: 2
                 },
                 {
-                    custom_id: `stop_${this.interaction.id}`,
+                    customID: `stop_${this.interaction.id}`,
                     label: this.client.translate("main.stop"),
                     style: 4,
                     type: 2
                 },
                 {
-                    custom_id: `bookmark_${this.interaction.id}`,
+                    customID: `bookmark_${this.interaction.id}`,
                     label: this.client.translate("main.bookmark"),
                     style: 2,
                     type: 2
                 },
                 {
-                    custom_id: `show_cover_${this.interaction.id}`,
+                    customID: `show_cover_${this.interaction.id}`,
                     label: this.client.translate("main.cover.show"),
                     style: 1,
                     type: 2
@@ -217,28 +217,28 @@ export class ReadSearchPaginator {
         };
 
         if (interaction instanceof ComponentInteraction) {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `read_${this.interaction.id}`:
                     this.initialisePaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
                 case `show_cover_${this.interaction.id}`:
                     resultEmbed.setImage(this.gallery.cover.url);
-                    this.interaction.editOriginalMessage({ components: [hideComponent], embeds: [resultEmbed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: [hideComponent], embeds: [resultEmbed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `hide_cover_${this.interaction.id}`:
                     resultEmbed.setImage("");
-                    this.interaction.editOriginalMessage({ components: [showComponent], embeds: [resultEmbed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: [showComponent], embeds: [resultEmbed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `bookmark_${this.interaction.id}`:
                     if (userData.bookmark.includes(this.embeds[0].author.name)) {
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${this.embeds[0].author.name}\`](${NReaderConstant.Source.ID(this.embeds[0].author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${this.embeds[0].author.name}\`](${NReaderConstant.Source.ID(this.embeds[0].author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -248,9 +248,9 @@ export class ReadSearchPaginator {
                         if (userData.bookmark.length === 25) {
                             return interaction.createMessage({
                                 embeds: [
-                                    new Utils.RichEmbed()
+                                    new RichEmbed()
                                         .setColor(this.client.config.BOT.COLOUR)
-                                        .setDescription(this.client.translate("main.bookmark.maxed"))
+                                        .setDescription(this.client.translate("main.bookmark.maxed")).data
                                 ],
                                 flags: Constants.MessageFlags.EPHEMERAL
                             });
@@ -258,9 +258,9 @@ export class ReadSearchPaginator {
 
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${this.embeds[0].author.name}\`](${NReaderConstant.Source.ID(this.embeds[0].author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${this.embeds[0].author.name}\`](${NReaderConstant.Source.ID(this.embeds[0].author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -270,7 +270,7 @@ export class ReadSearchPaginator {
 
                     break;
                 case `next_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed < this.embeds.length) {
                         this.embed++;
@@ -279,7 +279,7 @@ export class ReadSearchPaginator {
 
                     break;
                 case `previous_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed > 1) {
                         this.embed--;
@@ -288,45 +288,42 @@ export class ReadSearchPaginator {
 
                     break;
                 case `first_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = 1;
                     this.updatePaginator();
                     break;
                 case `last_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = this.embeds.length;
                     this.updatePaginator();
                     break;
                 case `jumpto_page_${this.interaction.id}`:
-                    this.client.createInteractionResponse(interaction.id, interaction.token, {
-                        data: ({
-                            components: [
-                                {
-                                    components: [
-                                        {
-                                            custom_id: "page_number",
-                                            label: this.client.translate("main.page.enter"),
-                                            placeholder: "5",
-                                            required: true,
-                                            style: 1,
-                                            type: 4
-                                        }
-                                    ],
-                                    type: 1
-                                }
-                            ],
-                            custom_id: `jumpto_page_modal_${this.interaction.id}`,
-                            title: this.client.translate("main.page.enter")
-                        } as any),
-                        type: Constants.InteractionResponseTypes.MODAL as any
+                    interaction.createModal({
+                        components: [
+                            {
+                                components: [
+                                    {
+                                        customID: "page_number",
+                                        label: this.client.translate("main.page.enter"),
+                                        placeholder: "5",
+                                        required: true,
+                                        style: 1,
+                                        type: 4
+                                    }
+                                ],
+                                type: 1
+                            }
+                        ],
+                        customID: `jumpto_page_modal_${this.interaction.id}`,
+                        title: this.client.translate("main.page.enter")
                     });
 
                     break;
             }
         } else {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `jumpto_page_modal_${this.interaction.id}`:
                     /* eslint-disable-next-line */
                     const page = parseInt(Util.getModalID(interaction, "page_number"));
@@ -334,9 +331,9 @@ export class ReadSearchPaginator {
                     if (isNaN(page)) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.invalid"))
+                                    .setDescription(this.client.translate("main.page.enter.invalid")).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -345,9 +342,9 @@ export class ReadSearchPaginator {
                     if (page > this.embeds.length) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -356,9 +353,9 @@ export class ReadSearchPaginator {
                     if (page <= 0) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -366,7 +363,7 @@ export class ReadSearchPaginator {
 
                     this.embed = page;
                     this.updatePaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
             }
         }
@@ -389,7 +386,7 @@ export class ReadSearchPaginator {
     }
 }
 
-export async function createReadSearchPaginator(client: NReaderClient, gallery: Gallery, interaction: CommandInteraction<TextableChannel>) {
+export async function createReadSearchPaginator(client: NReaderClient, gallery: Gallery, interaction: CommandInteraction<TextChannel>) {
     const paginator = new ReadSearchPaginator(client, gallery, interaction);
 
     paginator.runPaginator();

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -129,7 +129,7 @@ export class ReadSearchPaginator {
 
     /**
      * Start reading
-     * @param interaction Eris component interaction
+     * @param interaction Oceanic component interaction
      */
     public async onRead(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -1,7 +1,7 @@
 import { RequestHandler, Search } from "../API";
-import { ActionRow, AdvancedMessageContent, CommandInteraction, ComponentInteraction, Constants, EmbedOptions, Message, ModalSubmitInteraction, TextableChannel } from "eris";
+import { CommandInteraction, ComponentInteraction, Constants, EmbedOptions, InteractionContent, MessageActionRow, Message, ModalSubmitInteraction, TextChannel } from "oceanic.js";
 import { NReaderClient } from "../Client";
-import { Utils } from "givies-framework";
+import { RichEmbed } from "../Utils/RichEmbed";
 import { UserModel } from "../Models";
 import { ReadSearchPaginator } from "./ReadSearchPaginator";
 import { NReaderConstant } from "../Constant";
@@ -30,14 +30,14 @@ export class SearchPaginator {
     embeds: EmbedOptions[];
 
     /**
-     * Eris command interaction
+     * Oceanic command interaction
      */
-    interaction: CommandInteraction<TextableChannel>;
+    interaction: CommandInteraction<TextChannel>;
 
     /**
      * The message for embed pages
      */
-    message: Message<TextableChannel>;
+    message: Message<TextChannel>;
 
     /**
      * The read paginator
@@ -58,9 +58,9 @@ export class SearchPaginator {
      * Creates a search paginator
      * @param client NReader client
      * @param search The search result
-     * @param interaction Eris command interaction
+     * @param interaction Oceanic command interaction
      */
-    constructor(client: NReaderClient, search: Search, interaction: CommandInteraction<TextableChannel>) {
+    constructor(client: NReaderClient, search: Search, interaction: CommandInteraction<TextChannel>) {
         this.api = client.api;
         this.client = client;
         this.embed = 1;
@@ -84,7 +84,7 @@ export class SearchPaginator {
             const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-            return new Utils.RichEmbed()
+            return new RichEmbed()
                 .setAuthor(gallery.id, gallery.url)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`))
@@ -101,41 +101,41 @@ export class SearchPaginator {
                 .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
         });
 
-        this.embeds = embeds;
+        this.embeds = embeds.map((embed) => embed.data);
 
-        const messageContent: AdvancedMessageContent = {
+        const messageContent: InteractionContent = {
             components: [
                 {
                     components: [
-                        { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                        { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                        { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                        { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                        { custom_id: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                        { customID: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                        { customID: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                        { customID: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                        { customID: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
-                        { custom_id: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
+                        { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                        { customID: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                        { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -143,7 +143,7 @@ export class SearchPaginator {
             embeds: [this.embeds[this.embed - 1]]
         };
 
-        this.message = await this.interaction.editOriginalMessage(messageContent);
+        this.message = await this.interaction.editOriginal(messageContent);
         this.updatePaginator();
     }
 
@@ -151,90 +151,90 @@ export class SearchPaginator {
      * Start searching
      * @param interaction Eris component interaction
      */
-    public async onSearch(interaction: ComponentInteraction<TextableChannel> | ModalSubmitInteraction<TextableChannel>) {
+    public async onSearch(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;
 
-        const embed = new Utils.RichEmbed((interaction as ComponentInteraction<TextableChannel>).message ? (interaction as ComponentInteraction<TextableChannel>).message.embeds[0] : undefined);
+        const embed = new RichEmbed((interaction as ComponentInteraction<TextChannel>).message ? (interaction as ComponentInteraction<TextChannel>).message.embeds[0] : undefined);
         const userData = await UserModel.findOne({ id: interaction.member.id });
 
-        const hideComponent: ActionRow[] = [
+        const hideComponent: MessageActionRow[] = [
             {
                 components: [
-                    { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                    { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                    { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                    { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                    { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                    { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                    { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                    { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                    { custom_id: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                    { customID: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                    { customID: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                    { customID: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                    { customID: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
-                    { custom_id: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
+                    { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                    { customID: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                    { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                    { custom_id: `hide_cover_${this.interaction.id}`, label: this.client.translate("main.cover.hide"), style: 1, type: 2 }
+                    { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                    { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                    { customID: `hide_cover_${this.interaction.id}`, label: this.client.translate("main.cover.hide"), style: 1, type: 2 }
                 ],
                 type: 1
             }
         ];
 
-        const showComponent: ActionRow[] = [
+        const showComponent: MessageActionRow[] = [
             {
                 components: [
-                    { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                    { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                    { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                    { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                    { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                    { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                    { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                    { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                    { custom_id: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                    { custom_id: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                    { custom_id: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                    { customID: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                    { customID: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                    { customID: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                    { customID: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
-                    { custom_id: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
+                    { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                    { customID: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
                 ],
                 type: 1
             },
             {
                 components: [
-                    { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                    { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                    { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                    { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                    { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                    { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                 ],
                 type: 1
             }
         ];
 
         if (interaction instanceof ComponentInteraction) {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `read_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.api.getGallery(embed.author.name).then(async (gallery) => {
                         this.paginationEmbed = new ReadSearchPaginator(this.client, gallery, this.interaction);
@@ -244,27 +244,27 @@ export class SearchPaginator {
 
                     break;
                 case `see_more_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     this.initialisePaginator();
                     break;
                 case `show_cover_${this.interaction.id}`:
                     embed.setImage((await this.api.getGallery(embed.author.name)).cover.url);
-                    this.interaction.editOriginalMessage({ components: hideComponent, embeds: [embed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: hideComponent, embeds: [embed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `hide_cover_${this.interaction.id}`:
                     embed.setImage("");
-                    this.interaction.editOriginalMessage({ components: showComponent, embeds: [embed] });
-                    interaction.acknowledge();
+                    this.interaction.editOriginal({ components: showComponent, embeds: [embed.data] });
+                    interaction.deferUpdate();
                     break;
                 case `home_result_${this.interaction.id}`:
-                    this.interaction.editOriginalMessage({ components: showComponent, embeds: [this.embeds[this.embed - 1]] });
+                    this.interaction.editOriginal({ components: showComponent, embeds: [this.embeds[this.embed - 1]] });
                     this.paginationEmbed.stopPaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
                 case `stop_result_${this.interaction.id}`:
                     interaction.message.delete();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     this.stopPaginator();
 
                     try {
@@ -282,9 +282,9 @@ export class SearchPaginator {
                     if (userData.bookmark.includes(embed.author.name)) {
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.removed", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -294,9 +294,9 @@ export class SearchPaginator {
                         if (userData.bookmark.length === 25) {
                             return interaction.createMessage({
                                 embeds: [
-                                    new Utils.RichEmbed()
+                                    new RichEmbed()
                                         .setColor(this.client.config.BOT.COLOUR)
-                                        .setDescription(this.client.translate("main.bookmark.maxed"))
+                                        .setDescription(this.client.translate("main.bookmark.maxed")).data
                                 ],
                                 flags: Constants.MessageFlags.EPHEMERAL
                             });
@@ -304,9 +304,9 @@ export class SearchPaginator {
 
                         interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` }))
+                                    .setDescription(this.client.translate("main.bookmark.saved", { id: `[\`${embed.author.name}\`](${NReaderConstant.Source.ID(embed.author.name)})` })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -316,7 +316,7 @@ export class SearchPaginator {
 
                     break;
                 case `next_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed < this.embeds.length) {
                         this.embed++;
@@ -325,7 +325,7 @@ export class SearchPaginator {
 
                     break;
                 case `previous_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (this.embed > 1) {
                         this.embed--;
@@ -334,69 +334,63 @@ export class SearchPaginator {
 
                     break;
                 case `first_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = 1;
                     this.updatePaginator();
                     break;
                 case `last_result_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.embed = this.embeds.length;
                     this.updatePaginator();
                     break;
                 case `jumpto_result_${this.interaction.id}`:
-                    this.client.createInteractionResponse(interaction.id, interaction.token, {
-                        data: ({
-                            components: [
-                                {
-                                    components: [
-                                        {
-                                            custom_id: "result_number",
-                                            label: this.client.translate("main.result.enter"),
-                                            placeholder: "10",
-                                            required: true,
-                                            style: 1,
-                                            type: 4
-                                        }
-                                    ],
-                                    type: 1
-                                }
-                            ],
-                            custom_id: `jumpto_result_modal_${this.interaction.id}`,
-                            title: this.client.translate("main.result.enter")
-                        } as any),
-                        type: Constants.InteractionResponseTypes.MODAL as any
+                    interaction.createModal({
+                        components: [
+                            {
+                                components: [
+                                    {
+                                        customID: "result_number",
+                                        label: this.client.translate("main.result.enter"),
+                                        placeholder: "10",
+                                        required: true,
+                                        style: 1,
+                                        type: 4
+                                    }
+                                ],
+                                type: 1
+                            }
+                        ],
+                        customID: `jumpto_result_modal_${this.interaction.id}`,
+                        title: this.client.translate("main.result.enter")
                     });
 
                     break;
                 case `jumpto_result_page_${this.interaction.id}`:
-                    this.client.createInteractionResponse(interaction.id, interaction.token, {
-                        data: ({
-                            components: [
-                                {
-                                    components: [
-                                        {
-                                            custom_id: "result_page_number",
-                                            label: this.client.translate("main.page.enter"),
-                                            placeholder: "5",
-                                            required: true,
-                                            style: 1,
-                                            type: 4
-                                        }
-                                    ],
-                                    type: 1
-                                }
-                            ],
-                            custom_id: `jumpto_result_page_modal_${this.interaction.id}`,
-                            title: this.client.translate("main.page.enter")
-                        } as any),
-                        type: Constants.InteractionResponseTypes.MODAL as any
+                    interaction.createModal({
+                        components: [
+                            {
+                                components: [
+                                    {
+                                        customID: "result_page_number",
+                                        label: this.client.translate("main.page.enter"),
+                                        placeholder: "5",
+                                        required: true,
+                                        style: 1,
+                                        type: 4
+                                    }
+                                ],
+                                type: 1
+                            }
+                        ],
+                        customID: `jumpto_result_page_modal_${this.interaction.id}`,
+                        title: this.client.translate("main.page.enter")
                     });
 
                     break;
                 case `next_result_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (parseInt(embed.title.split(this.client.translate("main.page").split(" ")[0])[1].split("/")[0]) < this.search.numPages) {
                         this.api.searchGalleries(this.search.query, parseInt(embed.title.split(this.client.translate("main.page").split(" ")[0])[1].split("/")[0]) + 1).then((search) => {
@@ -409,7 +403,7 @@ export class SearchPaginator {
                                 const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
                                 const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-                                return new Utils.RichEmbed()
+                                return new RichEmbed()
                                     .setAuthor(gallery.id, gallery.url)
                                     .setColor(this.client.config.BOT.COLOUR)
                                     .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`)).setFooter(`⭐ ${gallery.favourites.toLocaleString()}`)
@@ -425,7 +419,7 @@ export class SearchPaginator {
                                     .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
                             });
 
-                            this.embeds = embeds;
+                            this.embeds = embeds.map((embed) => embed.data);
                             this.embed = 1;
                             this.updatePaginator();
                         });
@@ -433,7 +427,7 @@ export class SearchPaginator {
 
                     break;
                 case `previous_result_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     if (parseInt(embed.title.split(this.client.translate("main.page").split(" ")[0])[1].split("/")[0]) > 1) {
                         this.api.searchGalleries(this.search.query, parseInt(embed.title.split(this.client.translate("main.page").split(" ")[0])[1].split("/")[0]) - 1).then((search) => {
@@ -446,7 +440,7 @@ export class SearchPaginator {
                                 const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
                                 const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-                                return new Utils.RichEmbed()
+                                return new RichEmbed()
                                     .setAuthor(gallery.id, gallery.url)
                                     .setColor(this.client.config.BOT.COLOUR)
                                     .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`))
@@ -463,7 +457,7 @@ export class SearchPaginator {
                                     .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
                             });
 
-                            this.embeds = embeds;
+                            this.embeds = embeds.map((embed) => embed.data);
                             this.embed = 1;
                             this.updatePaginator();
                         });
@@ -471,7 +465,7 @@ export class SearchPaginator {
 
                     break;
                 case `first_result_page_${this.interaction.id}`:
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
 
                     this.api.searchGalleries(this.search.query, 1).then((search) => {
                         const title = search.result.map((gallery, index) => `\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``);
@@ -483,7 +477,7 @@ export class SearchPaginator {
                             const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
                             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-                            return new Utils.RichEmbed()
+                            return new RichEmbed()
                                 .setAuthor(gallery.id, gallery.url)
                                 .setColor(this.client.config.BOT.COLOUR)
                                 .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`))
@@ -500,13 +494,15 @@ export class SearchPaginator {
                                 .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
                         });
 
-                        this.embeds = embeds;
+                        this.embeds = embeds.map((embed) => embed.data);
                         this.embed = 1;
                         this.updatePaginator();
                     });
 
                     break;
                 case `last_result_page_${this.interaction.id}`:
+                    interaction.deferUpdate();
+                    
                     this.api.searchGalleries(this.search.query, this.search.numPages).then((search) => {
                         const title = search.result.map((gallery, index) => `\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``);
                         const embeds = search.result.map((gallery, index) => {
@@ -517,7 +513,7 @@ export class SearchPaginator {
                             const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
                             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-                            return new Utils.RichEmbed()
+                            return new RichEmbed()
                                 .setAuthor(gallery.id, gallery.url)
                                 .setColor(this.client.config.BOT.COLOUR)
                                 .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`))
@@ -534,7 +530,7 @@ export class SearchPaginator {
                                 .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
                         });
 
-                        this.embeds = embeds;
+                        this.embeds = embeds.map((embed) => embed.data);
                         this.embed = 1;
                         this.updatePaginator();
                     });
@@ -542,7 +538,7 @@ export class SearchPaginator {
                     break;
             }
         } else {
-            switch (interaction.data.custom_id) {
+            switch (interaction.data.customID) {
                 case `jumpto_result_modal_${this.interaction.id}`:
                     /* eslint-disable-next-line */
                     const pageResult = parseInt(Util.getModalID(interaction, "result_number"));
@@ -550,9 +546,9 @@ export class SearchPaginator {
                     if (isNaN(pageResult)) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.invalid"))
+                                    .setDescription(this.client.translate("main.result.enter.invalid")).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -561,9 +557,9 @@ export class SearchPaginator {
                     if (pageResult > this.embeds.length) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: pageResult.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: pageResult.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -572,9 +568,9 @@ export class SearchPaginator {
                     if (pageResult <= 0) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: pageResult.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.result.enter.unknown", { index: pageResult.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -582,7 +578,7 @@ export class SearchPaginator {
 
                     this.embed = pageResult;
                     this.updatePaginator();
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
                 case `jumpto_result_page_modal_${this.interaction.id}`:
                     /* eslint-disable-next-line */
@@ -591,9 +587,9 @@ export class SearchPaginator {
                     if (isNaN(page)) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.invalid"))
+                                    .setDescription(this.client.translate("main.page.enter.invalid")).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -602,9 +598,9 @@ export class SearchPaginator {
                     if (page > this.search.numPages) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -613,9 +609,9 @@ export class SearchPaginator {
                     if (page <= 0) {
                         return interaction.createMessage({
                             embeds: [
-                                new Utils.RichEmbed()
+                                new RichEmbed()
                                     .setColor(this.client.config.BOT.COLOUR)
-                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() }))
+                                    .setDescription(this.client.translate("main.page.enter.unknown", { index: page.toLocaleString() })).data
                             ],
                             flags: Constants.MessageFlags.EPHEMERAL
                         });
@@ -631,7 +627,7 @@ export class SearchPaginator {
                             const parodyTags: string[] = gallery.tags.parodies.map((tag) => tag.name);
                             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
-                            return new Utils.RichEmbed()
+                            return new RichEmbed()
                                 .setAuthor(gallery.id, gallery.url)
                                 .setColor(this.client.config.BOT.COLOUR)
                                 .setDescription(title.join("\n").replace(`\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``, `**\`🟥 ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\`**`))
@@ -648,12 +644,12 @@ export class SearchPaginator {
                                 .addField(contentTags.length > 1 ? this.client.translate("main.tags") : this.client.translate("main.tag"), `\`${contentTags.length !== 0 ? contentTags.join("`, `") : this.client.translate("main.none")}\``);
                         });
 
-                        this.embeds = embeds;
+                        this.embeds = embeds.map((embed) => embed.data);
                         this.embed = 1;
                         this.updatePaginator();
                     });
 
-                    interaction.acknowledge();
+                    interaction.deferUpdate();
                     break;
             }
         }
@@ -667,35 +663,35 @@ export class SearchPaginator {
             components: [
                 {
                     components: [
-                        { custom_id: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
-                        { custom_id: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
-                        { custom_id: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
+                        { customID: `first_result_${this.interaction.id}`, label: this.client.translate("main.result.first"), style: 1, type: 2 },
+                        { customID: `previous_result_${this.interaction.id}`, label: this.client.translate("main.result.previous"), style: 2, type: 2 },
+                        { customID: `stop_result_${this.interaction.id}`, label: this.client.translate("main.stop"), style: 4, type: 2 },
+                        { customID: `next_result_${this.interaction.id}`, label: this.client.translate("main.result.next"), style: 2, type: 2 },
+                        { customID: `last_result_${this.interaction.id}`, label: this.client.translate("main.result.last"), style: 1, type: 2 },
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
-                        { custom_id: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
-                        { custom_id: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
-                        { custom_id: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
+                        { customID: `first_result_page_${this.interaction.id}`, label: this.client.translate("main.page.first"), style: 1, type: 2 },
+                        { customID: `previous_result_page_${this.interaction.id}`, label: this.client.translate("main.page.previous"), style: 2, type: 2 },
+                        { customID: `next_result_page_${this.interaction.id}`, label: this.client.translate("main.page.next"), style: 2, type: 2 },
+                        { customID: `last_result_page_${this.interaction.id}`, label: this.client.translate("main.page.last"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
-                        { custom_id: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
+                        { customID: `jumpto_result_${this.interaction.id}`, label: this.client.translate("main.result.enter"), style: 1, type: 2 },
+                        { customID: `jumpto_result_page_${this.interaction.id}`, label: this.client.translate("main.page.enter"), style: 1, type: 2 }
                     ],
                     type: 1
                 },
                 {
                     components: [
-                        { custom_id: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
-                        { custom_id: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
-                        { custom_id: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
+                        { customID: `read_result_${this.interaction.id}`, label: this.client.translate("main.read"), style: 3, type: 2 },
+                        { customID: `bookmark_${this.interaction.id}`, label: this.client.translate("main.bookmark"), style: 2, type: 2 },
+                        { customID: `show_cover_${this.interaction.id}`, label: this.client.translate("main.cover.show"), style: 1, type: 2 }
                     ],
                     type: 1
                 }
@@ -721,7 +717,7 @@ export class SearchPaginator {
     }
 }
 
-export async function createSearchPaginator(client: NReaderClient, search: Search, interaction: CommandInteraction<TextableChannel>) {
+export async function createSearchPaginator(client: NReaderClient, search: Search, interaction: CommandInteraction<TextChannel>) {
     const paginator = new SearchPaginator(client, search, interaction);
 
     paginator.runPaginator();

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -502,7 +502,7 @@ export class SearchPaginator {
                     break;
                 case `last_result_page_${this.interaction.id}`:
                     interaction.deferUpdate();
-                    
+
                     this.api.searchGalleries(this.search.query, this.search.numPages).then((search) => {
                         const title = search.result.map((gallery, index) => `\`⬛ ${(index + 1).toString().length > 1 ? `${index + 1}` : `${index + 1} `}\` - [\`${gallery.id}\`](${gallery.url}) - \`${gallery.title.pretty.length >= 30 ? `${gallery.title.pretty.slice(0, 30)}...` : gallery.title.pretty}\``);
                         const embeds = search.result.map((gallery, index) => {

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -149,7 +149,7 @@ export class SearchPaginator {
 
     /**
      * Start searching
-     * @param interaction Eris component interaction
+     * @param interaction Oceanic component interaction
      */
     public async onSearch(interaction: ComponentInteraction<TextChannel> | ModalSubmitInteraction<TextChannel>) {
         if (interaction.member.bot) return;

--- a/framework/lib/Utils/Logger.ts
+++ b/framework/lib/Utils/Logger.ts
@@ -1,0 +1,104 @@
+import chalk from "chalk";
+import moment from "moment";
+
+interface LoggingOptions {
+    type?: string;
+    title: string;
+    subTitle?: string;
+    message: string;
+}
+
+interface CustomLoggingOptions {
+    type: string;
+    title: string;
+    subTitle?: string;
+    message: string;
+    color: string;
+}
+
+/**
+ * Represents a Logger class to facilitate the logging implementation
+ */
+export class Logger {
+    /**
+     * Logs an error logging message
+     * @param options The logging options
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    error(options: LoggingOptions): void {
+        return console.log(`${chalk.bgRed(` ${options.type ? options.type.toUpperCase() : "ERROR"} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.red(options.message)}`);
+    }
+
+    /**
+     * Logs an info logging message
+     * @param options The logging options
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    info(options: LoggingOptions): void {
+        return console.log(`${chalk.bgCyan(` ${options.type ? options.type.toUpperCase() : "INFO"} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.cyan(options.message)}`);
+    }
+
+    /**
+     * Logs a custom logging message
+     * @param options The logging options
+     * @param options.color The color of the log
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    log(options: CustomLoggingOptions): void {
+        return console.log(`${chalk.bgHex(options.color)(` ${options.type.toUpperCase()} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.hex(options.color)(options.message)}`);
+    }
+
+    /**
+     * Logs a success logging message
+     * @param options The logging options
+     * @param options.color The color of the log
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    success(options: LoggingOptions): void {
+        return console.log(`${chalk.bgGreen(` ${options.type ? options.type.toUpperCase() : "SUCCESS"} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.green(options.message)}`);
+    }
+
+    /**
+     * Logs a system logging message
+     * @param options The logging options
+     * @param options.color The color of the log
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    system(options: LoggingOptions): void {
+        return console.log(`${chalk.bgBlue(` ${options.type ? options.type.toUpperCase() : "SYSTEM"} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.blue(options.message)}`);
+    }
+
+    /**
+     * Logs a warning logging message
+     * @param options The logging options
+     * @param options.color The color of the log
+     * @param options.message The message of the log
+     * @param options.subTitle The sub title of the log. This comes after the title
+     * @param options.title The title of the log
+     * @param options.type The type of the log
+     * @returns {void}
+     */
+    warn(options: LoggingOptions): void {
+        return console.log(`${chalk.bgYellow(` ${options.type ? options.type.toUpperCase() : "WARNING"} `)}${options.subTitle ? chalk.bgWhite(chalk.black(` ${options.subTitle} `)) : ""} ${chalk.underline(options.title.toUpperCase())} - ${chalk.grey(moment().format("MMMM Do YYYY, hh:mm:ss A"))} - ${chalk.yellow(options.message)}`);
+    }
+}

--- a/framework/lib/Utils/RichEmbed.ts
+++ b/framework/lib/Utils/RichEmbed.ts
@@ -174,7 +174,7 @@ export class RichEmbed {
                 "Embed field descriptions cannot exceed 1024 characters"
             );
 
-        this.fields.push({ name, value, inline });
+        this.fields.push({ inline, name, value });
         return this;
     }
 
@@ -211,9 +211,9 @@ export class RichEmbed {
      */
     normalizeField(name: string, value: string, inline = false): EmbedField {
         return {
+            inline,
             name: Util.verifyString(name, RangeError, "EMBED_FIELD_NAME", false),
             value: Util.verifyString(value, RangeError, "EMBED_FIELD_VALUE", false),
-            inline,
         };
     }
 

--- a/framework/lib/Utils/RichEmbed.ts
+++ b/framework/lib/Utils/RichEmbed.ts
@@ -361,8 +361,10 @@ export class RichEmbed {
      * @returns {RichEmbed}
      */
     setTimestamp(timestamp?: string): RichEmbed {
-        if (Number.isNaN(new Date(timestamp).getTime()))
+        if (timestamp && Number.isNaN(new Date(timestamp).getTime())) {
             throw new Error("Invalid Date");
+        }
+
         this.timestamp = timestamp ? new Date(timestamp).toISOString() : new Date().toISOString();
         return this;
     }

--- a/framework/lib/Utils/RichEmbed.ts
+++ b/framework/lib/Utils/RichEmbed.ts
@@ -1,0 +1,412 @@
+import {
+    Embed,
+    EmbedAuthor,
+    EmbedField,
+    EmbedFooter,
+    EmbedImage,
+    EmbedOptions,
+} from "oceanic.js";
+import { Util } from "./Util";
+
+const HEX_REGEX = /^#?([a-fA-F0-9]{6})$/;
+const URL_REGEX =
+    /^http(s)?:\/\/[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
+
+/**
+ * Represents an Embed class constructor
+ */
+export class RichEmbed {
+    /**
+     * The author of the embed
+     * @type {EmbedAuthor}
+     */
+    author: EmbedAuthor;
+
+    /**
+     * The color of the embed. Color is in hex number
+     * @type {Number}
+     */
+    color: number;
+
+    /**
+     * The description of the embed
+     * @type {String}
+     */
+    description: string;
+
+    /**
+     * An array of fields of the embed
+     * @type {Array<EmbedField>}
+     */
+    fields: EmbedField[];
+
+    /**
+     * The footer of the embed
+     * @type {EmbedFooter}
+     */
+    footer: EmbedFooter;
+
+    /**
+     * The image of the embed
+     * @type {EmbedImage}
+     */
+    image: EmbedImage;
+
+    /**
+     * The thumbnail of the embed
+     * @type {EmbedImage}
+     */
+    thumbnail: EmbedImage;
+
+    /**
+     * The timestamp of the embed
+     * @type {String}
+     */
+    timestamp: string;
+
+    /**
+     * The title of the embed
+     * @type {String}
+     */
+    title: string;
+
+    /**
+     * The URL of the embed
+     * @type {String}
+     */
+    url: string;
+
+    /**
+     * Represents an Embed class constructor
+     * @param {EmbedOptions} data The embed data
+     * @param {Boolean} skipValidation
+     */
+    constructor(data: EmbedOptions = {}, skipValidation = false) {
+        if (data.title) this.title = data.title;
+        if (data.description) this.description = data.description;
+        if (data.url) this.url = data.url;
+        if (data.timestamp) this.timestamp = data.timestamp;
+        if (data.color) this.color = data.color;
+        if (data.footer) this.footer = data.footer;
+        if (data.image) this.image = data.image;
+        if (data.thumbnail) this.thumbnail = data.thumbnail;
+        if (data.author) this.author = data.author;
+        this.fields = [];
+
+        if (data.fields) {
+            // @ts-ignore:next-line
+            this.fields = skipValidation ? data.fields.map(Util.cloneObject) : this.normalizeFields(data.fields as EmbedField);
+        }
+    }
+
+    /**
+     * The whole data of the embed
+     */
+    get data(): EmbedOptions {
+        return {
+            author: this.author,
+            color: this.color,
+            description: this.description,
+            fields: this.fields,
+            footer: this.footer,
+            image: this.image,
+            thumbnail: this.thumbnail,
+            timestamp: this.timestamp,
+            title: this.title,
+            url: this.url,
+        };
+    }
+
+    /**
+     * The accumulated length for the embed title, description, field, footer text, and author name
+     * @type {Number}
+     * @readonly
+     */
+    get length(): number {
+        return (
+            (this.title?.length ?? 0) +
+            (this.description?.length ?? 0) +
+            (this.fields.length >= 1
+                ? this.fields.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0)
+                : 0) +
+            (this.footer?.text.length ?? 0) +
+            (this.author?.name.length ?? 0)
+        );
+    }
+
+    /**
+     * Compares two given embed field to check whether they are equal
+     * @param field The first field
+     * @param otherField The second field
+     * @returns {Boolean}
+     * @ignore
+     */
+    private _fieldEquals(field: EmbedField, otherField: EmbedField): boolean {
+        return field.name === otherField.name && field.value === otherField.value && field.inline === otherField.inline;
+    }
+
+    /**
+     * Adds a field to the embed. Max is 25
+     * @param name The name of the field
+     * @param value The value of the field
+     * @param inline Whether the field should be displayed inline
+     * @returns {RichEmbed}
+     */
+    addField(name: string, value: string, inline = false): RichEmbed {
+        if (this.fields.length >= 25)
+            throw new RangeError("Embeds cannot contain more than 25 fields");
+        if (typeof name !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type ${typeof name}`
+            );
+        if (typeof value !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type ${typeof value}`
+            );
+        if (typeof inline !== "boolean")
+            throw new TypeError(
+                `Expected type 'boolean', received type ${typeof inline}`
+            );
+        if (name.length > 256)
+            throw new RangeError("Embed field names cannot exceed 256 characters");
+        if (value.length > 1024)
+            throw new RangeError(
+                "Embed field descriptions cannot exceed 1024 characters"
+            );
+
+        this.fields.push({ name, value, inline });
+        return this;
+    }
+
+    /**
+     * Check if the embed is equal to another embed by comparing every single one of their properties
+     * @param embed The embed to compare with
+     * @returns {Boolean}
+     */
+    equals(embed: Embed): boolean {
+        return (
+            this.author?.name === embed.author?.name &&
+            this.author?.url === embed.author?.url &&
+            this.author?.iconURL === (embed.author?.iconURL ?? embed.author?.iconURL) &&
+            this.color === embed.color &&
+            this.title === embed.title &&
+            this.description === embed.description &&
+            this.url === embed.url &&
+            this.timestamp === embed.timestamp &&
+            this.fields.length === (embed.fields ? embed.fields?.length : 0) &&
+            this.fields.every((field, i) => this._fieldEquals(field, embed.fields[i])) &&
+            this.footer?.text === embed.footer?.text &&
+            this.footer?.iconURL === (embed.footer?.iconURL ?? embed.footer?.iconURL) &&
+            this.image?.url === embed.image?.url &&
+            this.thumbnail?.url === embed.thumbnail?.url
+        );
+    }
+
+    /**
+     * Normalize field input verifies strings
+     * @param name The name of the field
+     * @param value The value of the field
+     * @param inline Whether the field should be displayed inline
+     * @returns {EmbedField}
+     */
+    normalizeField(name: string, value: string, inline = false): EmbedField {
+        return {
+            name: Util.verifyString(name, RangeError, "EMBED_FIELD_NAME", false),
+            value: Util.verifyString(value, RangeError, "EMBED_FIELD_VALUE", false),
+            inline,
+        };
+    }
+
+    /**
+     * Normalize field input and resolves strings
+     * @param fields An array of fields to normalize
+     * @returns {EmbedField[]}
+     */
+    normalizeFields(...fields: EmbedField[]): EmbedField[] {
+        return fields
+            .flat(2)
+            .map(field =>
+                this.normalizeField(field.name, field.value, typeof field.inline === "boolean" ? field.inline : false),
+            );
+    }
+
+    /**
+     * Sets the author of the embed
+     * @param name The name of the author
+     * @param url The URL of the author
+     * @param iconURL The icon URL of the author
+     * @returns {RichEmbed}
+     */
+    setAuthor(name: string, url?: string, iconURL?: string): RichEmbed {
+        if (typeof name !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type ${typeof name}`
+            );
+        if (name.length > 256)
+            throw new RangeError("Embed author names cannot exceed 256 characters");
+        this.author = { name };
+
+        if (url !== undefined) {
+            if (typeof url !== "string")
+                throw new TypeError(
+                    `Expected type 'string', received type '${typeof url}'`
+                );
+            if (!URL_REGEX.test(url)) throw new Error("Not a well formed URL");
+            this.author.url = url;
+        }
+
+        if (iconURL !== undefined) {
+            if (typeof iconURL !== "string")
+                throw new TypeError(
+                    `Expected type 'string', received type '${typeof iconURL}'`
+                );
+            if (!iconURL.startsWith("attachment://") && !URL_REGEX.test(iconURL))
+                throw new Error("Not a well formed URL");
+            this.author.iconURL = iconURL;
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets the color of the embed
+     * @param color The color of the embed. Color must be in hex number
+     * @returns {RichEmbed}
+     */
+    setColor(color: string | number): RichEmbed {
+        if (typeof color !== "string" && typeof color !== "number")
+            throw new TypeError(
+                `Expected types 'string' or 'number', received type ${typeof color} instead`
+            );
+
+        if (typeof color === "number") {
+            if (color > 16777215 || color < 0) throw new RangeError("Invalid color");
+            this.color = color;
+        } else {
+            const match = color.match(HEX_REGEX);
+            if (!match) throw new Error("Invalid color");
+            this.color = parseInt(match[1], 16);
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets the description of the embed
+     * @param description The description of the embed
+     * @returns {RichEmbed}
+     */
+    setDescription(description: string): RichEmbed {
+        if (typeof description !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type '${typeof description}'`
+            );
+        if (description.length > 4096)
+            throw new RangeError("Embed descriptions cannot exceed 4096 characters");
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Sets the foother of the embed
+     * @param text The text of the embed
+     * @param iconURL The icon URL of the embed
+     * @returns {RichEmbed}
+     */
+    setFooter(text: string, iconURL: string = undefined): RichEmbed {
+        if (typeof text !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type ${typeof text}`
+            );
+        if (text.length > 2048)
+            throw new RangeError("Embed footer texts cannot exceed 2048 characters");
+        this.footer = { text };
+
+        if (iconURL !== undefined) {
+            if (typeof iconURL !== "string")
+                throw new TypeError(
+                    `Expected type 'string', received type '${typeof iconURL}'`
+                );
+            if (!iconURL.startsWith("attachment://") && !URL_REGEX.test(iconURL))
+                throw new Error("Not a well formed URL");
+            this.footer.iconURL = iconURL;
+        }
+
+        return this;
+    }
+
+    /**
+     * Sets the image of the embed
+     * @param imageURL The image URL of the embed
+     * @returns {RichEmbed}
+     */
+    setImage(imageURL: string): RichEmbed {
+        this.image = { url: imageURL };
+        return this;
+    }
+
+    /**
+     * Sets the thumbnail of the embed
+     * @param thumbnailURL The thumnail URL of the embed
+     * @returns {RichEmbed}
+     */
+    setThumbnail(thumbnailURL: string): RichEmbed {
+        this.thumbnail = { url: thumbnailURL };
+        return this;
+    }
+
+    /**
+     * Sets the timestamp of the embed
+     * @param timestamp The timestamp of the embed. Default timestamp is current date
+     * @returns {RichEmbed}
+     */
+    setTimestamp(timestamp?: string): RichEmbed {
+        if (Number.isNaN(new Date(timestamp).getTime()))
+            throw new Error("Invalid Date");
+        this.timestamp = timestamp ? new Date(timestamp).toISOString() : new Date().toISOString();
+        return this;
+    }
+
+    /**
+     * Sets the title of the embed
+     * @param title The title of the embed
+     * @returns {RichEmbed}
+     */
+    setTitle(title: string): RichEmbed {
+        if (typeof title !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type '${typeof title}'`
+            );
+        if (title.length > 256)
+            throw new RangeError("Embed titles cannot exceed 256 characters");
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * Sets the URL of the embed
+     * @param url The URL of the embed
+     * @returns {RichEmbed}
+     */
+    setURL(url: string): RichEmbed {
+        if (typeof url !== "string")
+            throw new TypeError(
+                `Expected type 'string', received type '${typeof url}'`
+            );
+        if (!URL_REGEX.test(url)) throw new Error("Not a well formed URL");
+        this.url = url;
+        return this;
+    }
+
+    /**
+     * Removes, replaces, and inserts fields in the embed. Max is 25
+     * @param index The index to start at
+     * @param deleteCount The number of fields to remove
+     * @param fields The replacing fields objects
+     * @returns {RichEmbed}
+     */
+    spliceFields(index: number, deleteCount: number, ...fields: any): RichEmbed {
+        this.fields.splice(index, deleteCount, ...this.normalizeFields(...fields));
+        return this;
+    }
+}

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -11,14 +11,13 @@
       "dependencies": {
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
-        "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
-        "givies-framework": "^2022.706.0",
         "http-cookie-agent": "^4.0.1",
         "i18next": "^21.8.13",
         "i18next-icu": "^2.0.3",
-        "moment": "^2.29.1",
+        "moment": "^2.29.4",
         "mongoose": "^6.0.12",
         "node-fetch": "^2.6.7",
+        "oceanic.js": "^1.0.2",
         "os-utils": "^0.0.14",
         "tough-cookie": "^4.0.0"
       },
@@ -61,6 +60,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
+      "optional": true,
+      "dependencies": {
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.36.2",
+        "prism-media": "^1.3.4",
+        "tslib": "^2.4.0",
+        "ws": "^8.8.1"
+      },
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -289,6 +304,15 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -820,14 +844,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -857,6 +873,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "optional": true
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -876,22 +898,6 @@
       "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/eris": {
-      "version": "0.17.2-everything.425b355",
-      "resolved": "git+ssh://git@github.com/DonovanDMC/eris.git#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
-      "integrity": "sha512-nyI2bxle8Q6kuky5wDaxpFo8i7iBaKASCkUMsXX+RLytm8tEziZfaHDsrPhtXb51nr/BTgdVeOgoUMorzVRy9g==",
-      "license": "MIT",
-      "dependencies": {
-        "ws": "^8.2.3"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      },
-      "optionalDependencies": {
-        "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1291,43 +1297,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
-    },
-    "node_modules/givies-framework": {
-      "version": "2022.706.0",
-      "resolved": "https://registry.npmjs.org/givies-framework/-/givies-framework-2022.706.0.tgz",
-      "integrity": "sha512-H1sCbmlRX23q3MwqUEPeV5/mbBT1T6M7ePX+a3U0mE0PEVnL8XED09iGUSN5QxlITY/hRqK4FRFegbXKnZ6Dvw==",
-      "dependencies": {
-        "@types/node": "^17.0.0",
-        "chalk": "^4.1.2",
-        "deepmerge": "^4.2.2",
-        "eris": "^0.17.1",
-        "moment": "^2.29.1",
-        "serialize-javascript": "^6.0.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=16.6.0"
-      }
-    },
-    "node_modules/givies-framework/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
-    },
-    "node_modules/givies-framework/node_modules/eris": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
-      "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
-      "dependencies": {
-        "ws": "^8.2.3"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      },
-      "optionalDependencies": {
-        "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.3"
-      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1877,6 +1846,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oceanic.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/oceanic.js/-/oceanic.js-1.0.2.tgz",
+      "integrity": "sha512-C9Bw+Q0SQZ3j5XtUyMzVKgfd2SexoFtpEiksdoEnErA6tzi0KYLJ82vUd4YLV92WootCTgkTSPQnP0CAgzfyiA==",
+      "dependencies": {
+        "undici": "^5.10.0",
+        "ws": "^8.8.1"
+      },
+      "engines": {
+        "node": ">=16.16.0"
+      },
+      "optionalDependencies": {
+        "@discordjs/voice": "^0.11.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1907,7 +1891,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
       "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/os-utils": {
       "version": "0.0.14",
@@ -1983,6 +1968,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prism-media": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.4.tgz",
+      "integrity": "sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==",
+      "optional": true,
+      "peerDependencies": {
+        "@discordjs/opus": "^0.8.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -2015,14 +2026,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2136,25 +2139,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/saslprep": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
@@ -2180,14 +2164,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -2544,12 +2520,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "optional": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2585,6 +2555,14 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/universalify": {
@@ -2667,9 +2645,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2727,6 +2705,19 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@discordjs/voice": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
+      "optional": true,
+      "requires": {
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.36.2",
+        "prism-media": "^1.3.4",
+        "tslib": "^2.4.0",
+        "ws": "^8.8.1"
       }
     },
     "@eslint/eslintrc": {
@@ -2937,6 +2928,15 @@
       "requires": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@typescript-eslint/eslint-plugin": {
@@ -3271,11 +3271,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-    },
     "denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -3296,6 +3291,12 @@
         "path-type": "^4.0.0"
       }
     },
+    "discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "optional": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3312,16 +3313,6 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
-      }
-    },
-    "eris": {
-      "version": "git+ssh://git@github.com/DonovanDMC/eris.git#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
-      "integrity": "sha512-nyI2bxle8Q6kuky5wDaxpFo8i7iBaKASCkUMsXX+RLytm8tEziZfaHDsrPhtXb51nr/BTgdVeOgoUMorzVRy9g==",
-      "from": "eris@github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
-      "requires": {
-        "opusscript": "^0.0.8",
-        "tweetnacl": "^1.0.3",
-        "ws": "^8.2.3"
       }
     },
     "escape-string-regexp": {
@@ -3634,37 +3625,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
-    },
-    "givies-framework": {
-      "version": "2022.706.0",
-      "resolved": "https://registry.npmjs.org/givies-framework/-/givies-framework-2022.706.0.tgz",
-      "integrity": "sha512-H1sCbmlRX23q3MwqUEPeV5/mbBT1T6M7ePX+a3U0mE0PEVnL8XED09iGUSN5QxlITY/hRqK4FRFegbXKnZ6Dvw==",
-      "requires": {
-        "@types/node": "^17.0.0",
-        "chalk": "^4.1.2",
-        "deepmerge": "^4.2.2",
-        "eris": "^0.17.1",
-        "moment": "^2.29.1",
-        "serialize-javascript": "^6.0.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
-        },
-        "eris": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
-          "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
-          "requires": {
-            "opusscript": "^0.0.8",
-            "tweetnacl": "^1.0.3",
-            "ws": "^8.2.3"
-          }
-        }
-      }
     },
     "glob": {
       "version": "7.2.3",
@@ -4059,6 +4019,16 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "oceanic.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/oceanic.js/-/oceanic.js-1.0.2.tgz",
+      "integrity": "sha512-C9Bw+Q0SQZ3j5XtUyMzVKgfd2SexoFtpEiksdoEnErA6tzi0KYLJ82vUd4YLV92WootCTgkTSPQnP0CAgzfyiA==",
+      "requires": {
+        "@discordjs/voice": "^0.11.0",
+        "undici": "^5.10.0",
+        "ws": "^8.8.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4086,7 +4056,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
       "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "os-utils": {
       "version": "0.0.14",
@@ -4138,6 +4109,13 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prism-media": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.4.tgz",
+      "integrity": "sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==",
+      "optional": true,
+      "requires": {}
+    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -4153,14 +4131,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "readdirp": {
       "version": "3.6.0",
@@ -4229,11 +4199,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
     "saslprep": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
@@ -4250,14 +4215,6 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
-      }
-    },
-    "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "requires": {
-        "randombytes": "^2.1.0"
       }
     },
     "shebang-command": {
@@ -4505,12 +4462,6 @@
         }
       }
     },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "optional": true
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4531,6 +4482,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -4594,9 +4550,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "requires": {}
     },
     "xtend": {

--- a/framework/package.json
+++ b/framework/package.json
@@ -14,7 +14,7 @@
   "keywords": [
     "typescript",
     "nreader",
-    "eris"
+    "oceanic"
   ],
   "author": "Reinhardt",
   "license": "MIT",

--- a/framework/package.json
+++ b/framework/package.json
@@ -35,14 +35,13 @@
   "dependencies": {
     "byte-size": "^8.1.0",
     "chalk": "^4.1.2",
-    "eris": "github:DonovanDMC/eris#f6d0bbf669ca5bbe1577a107c0570c149674cd8e",
-    "givies-framework": "^2022.706.0",
     "http-cookie-agent": "^4.0.1",
     "i18next": "^21.8.13",
     "i18next-icu": "^2.0.3",
-    "moment": "^2.29.1",
+    "moment": "^2.29.4",
     "mongoose": "^6.0.12",
     "node-fetch": "^2.6.7",
+    "oceanic.js": "^1.0.2",
     "os-utils": "^0.0.14",
     "tough-cookie": "^4.0.0"
   }


### PR DESCRIPTION
A huge breaking change! As whenever this pull request is merged, **NReader** is now officially using the [Oceanic](https://github.com/OceanicJS/Oceanic) library and no longer using [Eris](https://github.com/abalabahaha/eris) (rip to that) due to Eris' lack of progression in the past months.

The good news about this new library whose stable version was just released yesterday is that refactoring the whole code base from Eris took a very short period.

There are still several old codes from Eris which I haven't fully removed or otherwise refactored. I'm planning to properly fix and adjust them accordingly.