### PR TITLE
Fix embed author icon URL

### DIFF
--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -72,7 +72,7 @@ export async function readCommand(
             }
 
             const embed = new EmbedBuilder()
-                .setAuthor(gallery.id, gallery.url)
+                .setAuthor(gallery.id, undefined, gallery.url)
                 .setColor(client.config.BOT.COLOUR)
                 .addField(
                     client.translate("main.title"),

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -126,7 +126,7 @@ export class BookmarkPaginator {
             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id, gallery.url)
+                .setAuthor(gallery.id, undefined, gallery.url)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -68,7 +68,7 @@ export class ReadPaginator {
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id, page.url)
+                .setAuthor(gallery.id, undefined, page.url)
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {
@@ -173,7 +173,7 @@ export class ReadPaginator {
         const uploadedAt = `<t:${this.gallery.uploadDate.getTime() / 1000}:F>`;
 
         const resultEmbed = new EmbedBuilder()
-            .setAuthor(this.gallery.id, this.gallery.url)
+            .setAuthor(this.gallery.id, undefined, this.gallery.url)
             .setColor(this.client.config.BOT.COLOUR)
             .addField(
                 this.client.translate("main.title"),

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -77,7 +77,7 @@ export class ReadSearchPaginator {
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id, page.url)
+                .setAuthor(gallery.id, undefined, page.url)
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -120,7 +120,7 @@ export class SearchPaginator {
             const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id, gallery.url)
+                .setAuthor(gallery.id, undefined, gallery.url)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -761,7 +761,11 @@ export class SearchPaginator {
                                         }:F>`;
 
                                         return new EmbedBuilder()
-                                            .setAuthor(gallery.id, gallery.url)
+                                            .setAuthor(
+                                                gallery.id,
+                                                undefined,
+                                                gallery.url
+                                            )
                                             .setColor(
                                                 this.client.config.BOT.COLOUR
                                             )
@@ -1038,7 +1042,11 @@ export class SearchPaginator {
                                         }:F>`;
 
                                         return new EmbedBuilder()
-                                            .setAuthor(gallery.id, gallery.url)
+                                            .setAuthor(
+                                                gallery.id,
+                                                undefined,
+                                                gallery.url
+                                            )
                                             .setColor(
                                                 this.client.config.BOT.COLOUR
                                             )
@@ -1291,7 +1299,11 @@ export class SearchPaginator {
                                     }:F>`;
 
                                     return new EmbedBuilder()
-                                        .setAuthor(gallery.id, gallery.url)
+                                        .setAuthor(
+                                            gallery.id,
+                                            undefined,
+                                            gallery.url
+                                        )
                                         .setColor(this.client.config.BOT.COLOUR)
                                         .setDescription(
                                             title
@@ -1515,7 +1527,11 @@ export class SearchPaginator {
                                     }:F>`;
 
                                     return new EmbedBuilder()
-                                        .setAuthor(gallery.id, gallery.url)
+                                        .setAuthor(
+                                            gallery.id,
+                                            undefined,
+                                            gallery.url
+                                        )
                                         .setColor(this.client.config.BOT.COLOUR)
                                         .setDescription(
                                             title
@@ -1860,7 +1876,11 @@ export class SearchPaginator {
                                     }:F>`;
 
                                     return new EmbedBuilder()
-                                        .setAuthor(gallery.id, gallery.url)
+                                        .setAuthor(
+                                            gallery.id,
+                                            undefined,
+                                            gallery.url
+                                        )
                                         .setColor(this.client.config.BOT.COLOUR)
                                         .setDescription(
                                             title


### PR DESCRIPTION
It should apply to the author's URL instead of the icon but `EmbedBuilder` has a different parameter.