### PR TITLE
Set the correct temporary premium value for new users

### DIFF
--- a/config/config-example.json
+++ b/config/config-example.json
@@ -1,6 +1,7 @@
 {
     "API": {
-        "RESTRICTED_TAGS": []
+        "RESTRICTED_TAGS": [],
+        "TEMPORARY_PREMIUM": false
     },
     "BOT": {
         "ADMIN": [],

--- a/framework/lib/Commands/Modules/PremiumCommand.ts
+++ b/framework/lib/Commands/Modules/PremiumCommand.ts
@@ -53,6 +53,7 @@ export async function premiumCommand(
                 })
             );
 
+        client.config.API.TEMPORARY_PREMIUM = premium;
         usersData.forEach((user) => {
             user.settings.temporaryPremium = premium;
             user.save();

--- a/framework/lib/Events/Modules/InteractionCreateEvent.ts
+++ b/framework/lib/Events/Modules/InteractionCreateEvent.ts
@@ -37,7 +37,7 @@ export async function interactionCreateEvent(
             id: interaction.member.id,
             settings: {
                 premium: false,
-                temporaryPremium: false,
+                temporaryPremium: client.config.API.TEMPORARY_PREMIUM,
             },
         } as IUserSchema);
 

--- a/framework/lib/Interfaces/IConfig.ts
+++ b/framework/lib/Interfaces/IConfig.ts
@@ -1,5 +1,6 @@
 export interface IConfigAPI {
     RESTRICTED_TAGS: string[];
+    TEMPORARY_PREMIUM: boolean;
 }
 
 export interface IConfigBot {

--- a/framework/lib/Models/UserSchema.ts
+++ b/framework/lib/Models/UserSchema.ts
@@ -22,7 +22,6 @@ const userSchema = new Schema<IUserSchema>({
             type: Schema.Types.Boolean,
         },
         temporaryPremium: {
-            default: false,
             required: true,
             type: Schema.Types.Boolean,
         },


### PR DESCRIPTION
New users who are recently registered in the database will get their `temporaryPremium` based on the activation instead false by default.