### PR TITLE
Stop existing paginators after 2 hours

### DIFF
--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -665,6 +665,10 @@ export class BookmarkPaginator {
     public runPaginator() {
         this.client.on("interactionCreate", this.onSearch);
         this.running = true;
+
+        setTimeout(() => {
+            this.client.off("interactionCreate", this.onSearch);
+        }, 7200 * 1000);
     }
 
     /**

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -518,6 +518,10 @@ export class ReadPaginator {
     public runPaginator() {
         this.client.on("interactionCreate", this.onRead);
         this.running = true;
+
+        setTimeout(() => {
+            this.client.off("interactionCreate", this.onRead);
+        }, 7200 * 1000);
     }
 
     /**

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -374,6 +374,10 @@ export class ReadSearchPaginator {
     public runPaginator() {
         this.client.on("interactionCreate", this.onRead);
         this.running = true;
+
+        setTimeout(() => {
+            this.client.off("interactionCreate", this.onRead);
+        }, 7200 * 1000);
     }
 
     /**

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -2055,6 +2055,10 @@ export class SearchPaginator {
     public runPaginator() {
         this.client.on("interactionCreate", this.onSearch);
         this.running = true;
+
+        setTimeout(() => {
+            this.client.off("interactionCreate", this.onSearch);
+        }, 7200 * 1000);
     }
 
     /**


### PR DESCRIPTION
All paginators will automatically stop after running for 2 hours.

This will help reduce memory leaks and too many unnecessary events running in the background. Hopefully, this small workaround could be the solution whenever the bot is someday used in thousands of servers and multiple paginators are running simultaneously.