### PR TITLE
Assign buttons permissions to the original user

### DIFF
--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -293,7 +293,28 @@ export class BookmarkPaginator {
             | ComponentInteraction<TextChannel>
             | ModalSubmitInteraction<TextChannel>
     ) {
+        const userData = await UserModel.findOne({ id: interaction.user.id });
+        const authorData = await UserModel.findOne({
+            id: this.interaction.member.id,
+        });
+
         if (interaction.member.bot) return;
+
+        if (
+            (authorData.settings.premium ||
+                authorData.settings.temporaryPremium) &&
+            interaction.member.id !== this.interaction.member.id
+        ) {
+            const embed = new EmbedBuilder()
+                .setColor(this.client.config.BOT.COLOUR)
+                .setDescription(this.client.translate("main.denied"))
+                .toJSON();
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL,
+            });
+        }
 
         const embed = EmbedBuilder.loadFromJSON(
             (interaction as ComponentInteraction<TextChannel>).message
@@ -301,7 +322,6 @@ export class BookmarkPaginator {
                       .embeds[0]
                 : undefined
         );
-        const userData = await UserModel.findOne({ id: interaction.user.id });
 
         const hideComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -152,9 +152,29 @@ export class ReadPaginator {
             | ComponentInteraction<TextChannel>
             | ModalSubmitInteraction<TextChannel>
     ) {
+        const userData = await UserModel.findOne({ id: interaction.user.id });
+        const authorData = await UserModel.findOne({
+            id: this.interaction.member.id,
+        });
+
         if (interaction.member.bot) return;
 
-        const userData = await UserModel.findOne({ id: interaction.user.id });
+        if (
+            (authorData.settings.premium ||
+                authorData.settings.temporaryPremium) &&
+            interaction.member.id !== this.interaction.member.id
+        ) {
+            const embed = new EmbedBuilder()
+                .setColor(this.client.config.BOT.COLOUR)
+                .setDescription(this.client.translate("main.denied"))
+                .toJSON();
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL,
+            });
+        }
+
         const artistTags: string[] = this.gallery.tags.artists.map(
             (tag) => tag.name
         );

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -162,9 +162,28 @@ export class ReadSearchPaginator {
             | ComponentInteraction<TextChannel>
             | ModalSubmitInteraction<TextChannel>
     ) {
+        const userData = await UserModel.findOne({ id: interaction.member.id });
+        const authorData = await UserModel.findOne({
+            id: this.interaction.member.id,
+        });
+
         if (interaction.member.bot) return;
 
-        const userData = await UserModel.findOne({ id: interaction.member.id });
+        if (
+            (authorData.settings.premium ||
+                authorData.settings.temporaryPremium) &&
+            interaction.member.id !== this.interaction.member.id
+        ) {
+            const embed = new EmbedBuilder()
+                .setColor(this.client.config.BOT.COLOUR)
+                .setDescription(this.client.translate("main.denied"))
+                .toJSON();
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL,
+            });
+        }
 
         if (interaction instanceof ComponentInteraction) {
             switch (interaction.data.customID) {

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -318,7 +318,28 @@ export class SearchPaginator {
             | ComponentInteraction<TextChannel>
             | ModalSubmitInteraction<TextChannel>
     ) {
+        const userData = await UserModel.findOne({ id: interaction.user.id });
+        const authorData = await UserModel.findOne({
+            id: this.interaction.member.id,
+        });
+
         if (interaction.member.bot) return;
+
+        if (
+            (authorData.settings.premium ||
+                authorData.settings.temporaryPremium) &&
+            interaction.member.id !== this.interaction.member.id
+        ) {
+            const embed = new EmbedBuilder()
+                .setColor(this.client.config.BOT.COLOUR)
+                .setDescription(this.client.translate("main.denied"))
+                .toJSON();
+
+            return interaction.createMessage({
+                embeds: [embed],
+                flags: Constants.MessageFlags.EPHEMERAL,
+            });
+        }
 
         const embed = EmbedBuilder.loadFromJSON(
             (interaction as ComponentInteraction<TextChannel>).message
@@ -326,7 +347,6 @@ export class SearchPaginator {
                       .embeds[0]
                 : undefined
         );
-        const userData = await UserModel.findOne({ id: interaction.user.id });
 
         const hideComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(

--- a/framework/lib/Types/TTranslationKey.ts
+++ b/framework/lib/Types/TTranslationKey.ts
@@ -34,6 +34,7 @@ type TMainKey =
     | "main.characters"
     | "main.cover.hide"
     | "main.cover.show"
+    | "main.denied"
     | "main.detail"
     | "main.error"
     | "main.home"

--- a/localisation/en/main.json
+++ b/localisation/en/main.json
@@ -11,6 +11,7 @@
     "main.characters": "Characters",
     "main.cover.hide": "Hide Cover",
     "main.cover.show": "Show Cover",
+    "main.denied": "These buttons are not for you!",
     "main.detail": "See More",
     "main.error": "Something went wrong, please try again later!",
     "main.home": "Home",

--- a/localisation/id/main.json
+++ b/localisation/id/main.json
@@ -11,6 +11,7 @@
     "main.characters": "Karakter",
     "main.cover.hide": "Sembunyikan Sampul",
     "main.cover.show": "Tampilkan Sampul",
+    "main.denied": "Tombol ini bukan untuk anda!",
     "main.detail": "Lihat Lebih",
     "main.error": "Ada sesuatu yang salah, silakan coba lagi nanti!",
     "main.home": "Beranda",

--- a/localisation/ja/main.json
+++ b/localisation/ja/main.json
@@ -11,6 +11,7 @@
     "main.characters": "キャラクター",
     "main.cover.hide": "カバーを非表示",
     "main.cover.show": "カバーを表示",
+    "main.denied": "これらのボタンはあなたのためではありません！",
     "main.detail": "もっと見る",
     "main.error": "エラーが発生しました。再試行してください！",
     "main.home": "ホーム",

--- a/localisation/zh/main.json
+++ b/localisation/zh/main.json
@@ -11,6 +11,7 @@
     "main.characters": "字符",
     "main.cover.hide": "隐藏封面",
     "main.cover.show": "显示封面",
+    "main.denied": "这些按钮不是你的！",
     "main.detail": "查看更多",
     "main.error": "发生错误，请稍后重试！",
     "main.home": "主页",


### PR DESCRIPTION
Paginator buttons are designated to be clickable by the original user who initiated the paginator and random users shouldn't be able to click on any of them (Only for premium users). An option for premium users to disable this setting will be configurable in future versions.

A new localisation string has also been added.