### PR TITLE
Fix GitHub all checks return as success

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "ts-node-dev ./src/NReader.ts",
     "start": "ts-node ./src/NReader.ts",
-    "lint": "eslint --ext \".ts\" --ignore-path .gitignore . && echo \"\u001b[1m\u001b[32mSUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mFAILED\u001b[39m\u001b[22m\"",
-    "lint:fix": "eslint --ext \".ts\" --ignore-path .gitignore . --fix && echo \"\u001b[1m\u001b[32mSUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mFAILED\u001b[39m\u001b[22m\""
+    "lint": "eslint --ext \".ts\" --ignore-path .gitignore .",
+    "lint:fix": "eslint --ext \".ts\" --ignore-path .gitignore . --fix"
   },
   "keywords": [
     "reader"

--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -52,7 +52,7 @@ export class NReaderClient extends Client {
     /**
      * Manage the database stats
      */
-    public stats = new StatsManager(this);
+    public stats = new StatsManager(this)
 
     /**
      * Initialise every handler for NReader

--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -52,7 +52,7 @@ export class NReaderClient extends Client {
     /**
      * Manage the database stats
      */
-    public stats = new StatsManager(this)
+    public stats = new StatsManager(this);
 
     /**
      * Initialise every handler for NReader

--- a/framework/package.json
+++ b/framework/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "build:locale": "ts-node ./lib/Modules/LocalisationCompiler.ts",
-    "lint": "eslint --ext \".ts\" --ignore-path .gitignore . && prettier --check . && echo \"\u001b[1m\u001b[32mLINT SUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mLINT FAILED\u001b[39m\u001b[22m\"",
-    "lint:fix": "eslint --ext \".ts\" --ignore-path .gitignore . --fix && prettier --write --list-different . && echo \"\u001b[1m\u001b[32mLINT SUCCESS\u001b[39m\u001b[22m\" || echo \"\u001b[1m\u001b[31mLINT FAILED\u001b[39m\u001b[22m\""
+    "lint": "eslint --ext \".ts\" --ignore-path .gitignore . && prettier --check .",
+    "lint:fix": "eslint --ext \".ts\" --ignore-path .gitignore . --fix && prettier --write --list-different ."
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
This one might be weird as GitHub marked all checks passed even though there aren't. My assumption is that GitHub thought the `LINT SUCCESS` or `LINT FAILED` echo text is the final check.