### PR TITLE
Fix `shardDisconnect` wrong error message

### DIFF
--- a/bot/src/Events/ShardDisconnect.ts
+++ b/bot/src/Events/ShardDisconnect.ts
@@ -2,7 +2,7 @@ import { NReaderEvent, NReaderInterface } from "nreader-framework/lib";
 
 export const event: NReaderInterface.IEvent = {
     name: "shardDisconnect",
-    run: (client, err: Error, id: number) => {
+    run: (client, err: string, id: number) => {
         return new NReaderEvent(client, err, id).shardDisconnectEvent();
     }
 };

--- a/framework/lib/Events/Modules/ShardDisconnectEvent.ts
+++ b/framework/lib/Events/Modules/ShardDisconnectEvent.ts
@@ -2,12 +2,12 @@ import { NReaderClient } from "../../Client";
 
 export function shardDisconnectEvent(
     client: NReaderClient,
-    err: Error,
+    err: string,
     id: number
 ) {
     if (client.shards.get(id)) {
         client.logger.error({
-            message: err.message,
+            message: err,
             subTitle: "NReaderFramework::Events::ShardDisconnect",
             title: `SHARD ${id}`,
         });


### PR DESCRIPTION
`err` is a type of string, not `Error`.