### PR TITLE
Set `messages` collection limit to 0

### DIFF
--- a/bot/src/NReader.ts
+++ b/bot/src/NReader.ts
@@ -3,6 +3,9 @@ import * as Config from "../../config/config.json";
 
 const client = new NReaderClient({
     auth: Config.BOT.TOKEN,
+    collectionLimits: {
+        messages: 0
+    },
     defaultImageFormat: "png",
     gateway: {
         intents: ["GUILDS"],


### PR DESCRIPTION
- Replicated from #147 

This replication intends to disable the cache for messages. It was reverted (24915582) due to a false error.