### PR TITLE
Bypass Cloudflare DDoS protection

### DIFF
--- a/framework/lib/Client.ts
+++ b/framework/lib/Client.ts
@@ -1,12 +1,13 @@
 import { APIStats } from "./Utils/APIStats";
+import { API } from "nhentai-api";
 import { Client, ClientEvents } from "oceanic.js";
+import { CookieJar } from "tough-cookie";
 import { Collection } from "./Utils";
 import { ICommand, IConfig, IEvent, IGuildSchemaSettings } from "./Interfaces";
 import { TLocale, TranslationKey } from "./Types";
 import { connect } from "mongoose";
 import { GuildModel } from "./Models";
 import { Logger } from "./Utils/Logger";
-import { RequestHandler } from "./API";
 import { StatsManager } from "./Modules/StatsManager";
 import { join } from "path";
 import { readdirSync } from "fs";
@@ -17,13 +18,9 @@ import localeID from "./Locales/id.json";
 import localeJA from "./Locales/ja.json";
 import localeZH from "./Locales/zh.json";
 import localeEO from "./Locales/eo.json";
+import { HttpsCookieAgent } from "http-cookie-agent/http";
 
 export class NReaderClient extends Client {
-    /**
-     * NHentai API
-     */
-    public api = new RequestHandler();
-
     /**
      * BotList API Stats
      */
@@ -53,6 +50,19 @@ export class NReaderClient extends Client {
      * Manage the database stats
      */
     public stats = new StatsManager(this);
+
+    /**
+     * NHentai API
+     */
+    public get api() {
+        const jar = new CookieJar();
+        const agent = new HttpsCookieAgent({ cookies: { jar } });
+
+        jar.setCookie(this.config.API.COOKIE, "https://nhentai.net");
+
+        /* @ts-ignore */
+        return new API({ agent });
+    }
 
     /**
      * Initialise every handler for NReader

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -6,7 +6,7 @@ import {
     TextChannel,
 } from "oceanic.js";
 import { ComponentBuilder, EmbedBuilder } from "@oceanicjs/builders";
-import { Gallery } from "../../API";
+import { Book } from "nhentai-api";
 import { UserModel } from "../../Models";
 import { createBookmarkPaginator } from "../../Modules/BookmarkPaginator";
 import { setTimeout } from "node:timers/promises";
@@ -72,28 +72,28 @@ export async function bookmarkCommand(
         await setTimeout(2000);
 
         const bookmarkedTitle: string[] = [];
-        const galleries: Gallery[] = [];
+        const galleries: Book[] = [];
 
         for (let i = 0; i < bookmarked.length; i++) {
             let title: string;
-            let gallery: Gallery;
+            let gallery: Book;
 
             try {
                 title = await client.api
-                    .getGallery(bookmarked[i])
+                    .getBook(parseInt(bookmarked[i]))
                     .then(
                         (gallery) =>
                             `\`⬛ ${
                                 (i + 1).toString().length > 1
                                     ? `${i + 1}`
                                     : `${i + 1} `
-                            }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                                 gallery.title.pretty.length >= 30
                                     ? `${gallery.title.pretty.slice(0, 30)}...`
                                     : gallery.title.pretty
                             }\``
                     );
-                gallery = await client.api.getGallery(bookmarked[i]);
+                gallery = await client.api.getBook(parseInt(bookmarked[i]));
             } catch (err) {
                 const embed = new EmbedBuilder()
                     .setColor(client.config.BOT.COLOUR)

--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -87,7 +87,9 @@ export async function bookmarkCommand(
                                 (i + 1).toString().length > 1
                                     ? `${i + 1}`
                                     : `${i + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${
                                 gallery.title.pretty.length >= 30
                                     ? `${gallery.title.pretty.slice(0, 30)}...`
                                     : gallery.title.pretty

--- a/framework/lib/Commands/Modules/ProfileCommand.ts
+++ b/framework/lib/Commands/Modules/ProfileCommand.ts
@@ -69,7 +69,9 @@ export async function profileCommand(
             true
         )
         .setThumbnail(user.avatarURL())
-        .setTitle(client.translate("general.profile.title", { user: user.username }))
+        .setTitle(
+            client.translate("general.profile.title", { user: user.username })
+        )
         .toJSON();
 
     return interaction.createMessage({

--- a/framework/lib/Commands/Modules/ProfileCommand.ts
+++ b/framework/lib/Commands/Modules/ProfileCommand.ts
@@ -69,7 +69,7 @@ export async function profileCommand(
             true
         )
         .setThumbnail(user.avatarURL())
-        .setTitle(client.translate("general.profile.title", { user: user.tag }))
+        .setTitle(client.translate("general.profile.title", { user: user.username }))
         .toJSON();
 
     return interaction.createMessage({

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -31,9 +31,7 @@ export async function readCommand(
     client.api
         .getBook(parseInt(galleryID))
         .then(async (gallery) => {
-            const artistTags: string[] = gallery.artists.map(
-                (tag) => tag.name
-            );
+            const artistTags: string[] = gallery.artists.map((tag) => tag.name);
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
@@ -53,7 +51,11 @@ export async function readCommand(
                     : contentTags.join("`, `");
 
             const embed = new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    `https://nhentai.net/g/${gallery.id}`
+                )
                 .setColor(client.config.BOT.COLOUR)
                 .addField(
                     client.translate("main.title"),

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -29,31 +29,31 @@ export async function readCommand(
     await setTimeout(2000);
 
     client.api
-        .getGallery(galleryID)
+        .getBook(parseInt(galleryID))
         .then(async (gallery) => {
-            const artistTags: string[] = gallery.tags.artists.map(
+            const artistTags: string[] = gallery.artists.map(
                 (tag) => tag.name
             );
-            const characterTags: string[] = gallery.tags.characters.map(
+            const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.tags.map(
+            const contentTags: string[] = gallery.pureTags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
-            const languageTags: string[] = gallery.tags.languages.map(
+            const languageTags: string[] = gallery.languages.map(
                 (tag) => tag.name.charAt(0).toUpperCase() + tag.name.slice(1)
             );
-            const parodyTags: string[] = gallery.tags.parodies.map(
+            const parodyTags: string[] = gallery.parodies.map(
                 (tag) => tag.name
             );
-            const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
+            const uploadedAt = `<t:${gallery.uploaded.getTime() / 1000}:F>`;
             const stringTag =
                 contentTags.join("`, `").length >= 1024
                     ? `${contentTags.join("`, `").slice(0, 1010)}...`
                     : contentTags.join("`, `");
 
             const embed = new EmbedBuilder()
-                .setAuthor(gallery.id, undefined, gallery.url)
+                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
                 .setColor(client.config.BOT.COLOUR)
                 .addField(
                     client.translate("main.title"),
@@ -119,8 +119,8 @@ export async function readCommand(
                             : client.translate("main.none")
                     }\``
                 )
-                .setFooter(`⭐ ${gallery.favourites.toLocaleString()}`)
-                .setThumbnail(gallery.cover.url);
+                .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
+                .setThumbnail(client.api.getImageURL(gallery.cover));
 
             const components = new ComponentBuilder<MessageActionRow>()
                 .addInteractionButton(

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -53,7 +53,9 @@ export async function searchCommand(
                         (index + 1).toString().length > 1
                             ? `${index + 1}`
                             : `${index + 1} `
-                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                        gallery.id
+                    }) - \`${
                         gallery.title.pretty.length >= 30
                             ? `${gallery.title.pretty.slice(0, 30)}...`
                             : gallery.title.pretty

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -33,9 +33,9 @@ export async function searchCommand(
     await setTimeout(2000);
 
     client.api
-        .searchGalleries(encodeURIComponent(query), page || 1, sort || "")
+        .search(encodeURIComponent(query), page || 1, sort || "")
         .then(async (search) => {
-            if (search.result.length === 0) {
+            if (search.books.length === 0) {
                 const embed = new EmbedBuilder()
                     .setColor(client.config.BOT.COLOUR)
                     .setDescription(
@@ -47,13 +47,13 @@ export async function searchCommand(
                 });
             }
 
-            const title = search.result.map(
+            const title = search.books.map(
                 (gallery, index) =>
                     `\`⬛ ${
                         (index + 1).toString().length > 1
                             ? `${index + 1}`
                             : `${index + 1} `
-                    }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                         gallery.title.pretty.length >= 30
                             ? `${gallery.title.pretty.slice(0, 30)}...`
                             : gallery.title.pretty
@@ -66,7 +66,7 @@ export async function searchCommand(
                 .setTitle(
                     client.translate("main.page", {
                         firstIndex: search.page,
-                        lastIndex: search.numPages.toLocaleString(),
+                        lastIndex: search.pages.toLocaleString(),
                     })
                 );
 

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -50,7 +50,9 @@ export async function searchSimilarCommand(
                         (index + 1).toString().length > 1
                             ? `${index + 1}`
                             : `${index + 1} `
-                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                        gallery.id
+                    }) - \`${
                         gallery.title.pretty.length >= 30
                             ? `${gallery.title.pretty.slice(0, 30)}...`
                             : gallery.title.pretty

--- a/framework/lib/Commands/Modules/SearchSimilarCommand.ts
+++ b/framework/lib/Commands/Modules/SearchSimilarCommand.ts
@@ -32,9 +32,9 @@ export async function searchSimilarCommand(
     await setTimeout(2000);
 
     client.api
-        .getGalleryRelated(galleryID)
+        .searchAlike(parseInt(galleryID))
         .then(async (search) => {
-            if (search.result.length === 0) {
+            if (search.books.length === 0) {
                 const embed = new EmbedBuilder()
                     .setColor(client.config.BOT.COLOUR)
                     .setDescription(client.translate("main.search.empty"));
@@ -44,13 +44,13 @@ export async function searchSimilarCommand(
                 });
             }
 
-            const title = search.result.map(
+            const title = search.books.map(
                 (gallery, index) =>
                     `\`⬛ ${
                         (index + 1).toString().length > 1
                             ? `${index + 1}`
                             : `${index + 1} `
-                    }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                         gallery.title.pretty.length >= 30
                             ? `${gallery.title.pretty.slice(0, 30)}...`
                             : gallery.title.pretty
@@ -63,7 +63,7 @@ export async function searchSimilarCommand(
                 .setTitle(
                     client.translate("main.page", {
                         firstIndex: search.page,
-                        lastIndex: search.numPages.toLocaleString(),
+                        lastIndex: search.pages.toLocaleString(),
                     })
                 );
 

--- a/framework/lib/Interfaces/IConfig.ts
+++ b/framework/lib/Interfaces/IConfig.ts
@@ -1,4 +1,5 @@
 export interface IConfigAPI {
+    COOKIE: string;
     RESTRICTED_TAGS: string[];
     TEMPORARY_PREMIUM: boolean;
 }

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -1,4 +1,4 @@
-import { RequestHandler, Gallery } from "../API";
+import { API, Book } from "nhentai-api";
 import {
     CommandInteraction,
     ComponentInteraction,
@@ -25,7 +25,7 @@ export class BookmarkPaginator {
     /**
      * NHentai API
      */
-    api: RequestHandler;
+    api: API;
 
     /**
      * An array of bookmark chunks
@@ -50,7 +50,7 @@ export class BookmarkPaginator {
     /**
      * Bookmarked doujin
      */
-    galleries: Gallery[];
+    galleries: Book[];
 
     /**
      * Oceanic command interaction
@@ -90,7 +90,7 @@ export class BookmarkPaginator {
      */
     constructor(
         client: NReaderClient,
-        galleries: Gallery[],
+        galleries: Book[],
         interaction: CommandInteraction<TextChannel>,
         user: User
     ) {
@@ -113,12 +113,12 @@ export class BookmarkPaginator {
      * @returns {Promise<void>}
      */
     private async getBookmarkPage() {
-        const galleries: Gallery[] = [];
+        const galleries: Book[] = [];
         const bookmarked = this.bookmarkChunks[this.page - 1];
 
         for (let i = 0; i < bookmarked.length; i++) {
-            const gallery: Gallery = await this.client.api.getGallery(
-                bookmarked[i]
+            const gallery: Book = await this.client.api.getBook(
+                parseInt(bookmarked[i])
             );
 
             galleries.push(gallery);
@@ -130,34 +130,34 @@ export class BookmarkPaginator {
                     (index + 1).toString().length > 1
                         ? `${index + 1}`
                         : `${index + 1} `
-                }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                     gallery.title.pretty
                 }\``
         );
         const embeds = galleries.map((gallery, index) => {
-            const artistTags: string[] = gallery.tags.artists.map(
+            const artistTags: string[] = gallery.artists.map(
                 (tag) => tag.name
             );
-            const characterTags: string[] = gallery.tags.characters.map(
+            const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.tags.map(
+            const contentTags: string[] = gallery.tags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
-            const languageTags: string[] = gallery.tags.languages.map(
+            const languageTags: string[] = gallery.languages.map(
                 (tag) => tag.name.charAt(0).toUpperCase() + tag.name.slice(1)
             );
-            const parodyTags: string[] = gallery.tags.parodies.map(
+            const parodyTags: string[] = gallery.parodies.map(
                 (tag) => tag.name
             );
-            const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
+            const uploadedAt = `<t:${gallery.uploaded.getTime() / 1000}:F>`;
             const stringTag =
                 contentTags.join("`, `").length >= 1024
                     ? `${contentTags.join("`, `").slice(0, 1010)}...`
                     : contentTags.join("`, `");
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id, undefined, gallery.url)
+                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -167,26 +167,26 @@ export class BookmarkPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                                 gallery.title.pretty
                             }\``,
                             `**\`🟥 ${
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                                 gallery.title.pretty
                             }\`**`
                         )
                 )
-                .setFooter(`⭐ ${gallery.favourites.toLocaleString()}`)
+                .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
                 .setTitle(
                     this.client.translate("main.page", {
                         firstIndex: this.page,
                         lastIndex: this.bookmarkChunks.length,
                     })
                 )
-                .setThumbnail(gallery.cover.url)
+                .setThumbnail(this.client.api.getImageURL(gallery.cover))
                 .addField(
                     this.client.translate("main.title"),
                     `\`${gallery.title.pretty}\``
@@ -275,7 +275,7 @@ export class BookmarkPaginator {
                     (index + 1).toString().length > 1
                         ? `${index + 1}`
                         : `${index + 1} `
-                }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                     gallery.title.pretty
                 }\``
         );
@@ -283,29 +283,29 @@ export class BookmarkPaginator {
         this.bookmarkChunks = Util.arrayToChunks(userData.bookmark, 5);
 
         const embeds = this.galleries.map((gallery, index) => {
-            const artistTags: string[] = gallery.tags.artists.map(
+            const artistTags: string[] = gallery.artists.map(
                 (tag) => tag.name
             );
-            const characterTags: string[] = gallery.tags.characters.map(
+            const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.tags.map(
+            const contentTags: string[] = gallery.tags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
-            const languageTags: string[] = gallery.tags.languages.map(
+            const languageTags: string[] = gallery.languages.map(
                 (tag) => tag.name.charAt(0).toUpperCase() + tag.name.slice(1)
             );
-            const parodyTags: string[] = gallery.tags.parodies.map(
+            const parodyTags: string[] = gallery.parodies.map(
                 (tag) => tag.name
             );
-            const uploadedAt = `<t:${gallery.uploadDate.getTime() / 1000}:F>`;
+            const uploadedAt = `<t:${gallery.uploaded.getTime() / 1000}:F>`;
             const stringTag =
                 contentTags.join("`, `").length >= 1024
                     ? `${contentTags.join("`, `").slice(0, 1010)}...`
                     : contentTags.join("`, `");
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id, undefined, gallery.url)
+                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -315,26 +315,26 @@ export class BookmarkPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                                 gallery.title.pretty
                             }\``,
                             `**\`🟥 ${
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](${gallery.url}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
                                 gallery.title.pretty
                             }\`**`
                         )
                 )
-                .setFooter(`⭐ ${gallery.favourites.toLocaleString()}`)
+                .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
                 .setTitle(
                     this.client.translate("main.page", {
                         firstIndex: this.page,
                         lastIndex: this.bookmarkChunks.length,
                     })
                 )
-                .setThumbnail(gallery.cover.url)
+                .setThumbnail(this.client.api.getImageURL(gallery.cover))
                 .addField(
                     this.client.translate("main.title"),
                     `\`${gallery.title.pretty}\``
@@ -671,7 +671,7 @@ export class BookmarkPaginator {
                     interaction.deferUpdate();
 
                     this.api
-                        .getGallery(embed.toJSON().author.name)
+                        .getBook(parseInt(embed.toJSON().author.name))
                         .then(async (gallery) => {
                             this.paginationEmbed = new ReadSearchPaginator(
                                 this.client,
@@ -689,10 +689,10 @@ export class BookmarkPaginator {
                     this.initialisePaginator();
                     break;
                 case `show_cover_${this.interaction.id}`:
-                    embed.setImage(
-                        (await this.api.getGallery(embed.toJSON().author.name))
-                            .cover.url
-                    );
+                    embed.setImage(this.client.api.getImageURL(
+                        (await this.api.getBook(parseInt(embed.toJSON().author.name)))
+                            .cover
+                    ));
                     this.interaction.editOriginal({
                         components: hideComponent,
                         embeds: [embed.toJSON()],
@@ -1171,7 +1171,7 @@ export class BookmarkPaginator {
 
 export async function createBookmarkPaginator(
     client: NReaderClient,
-    galleries: Gallery[],
+    galleries: Book[],
     interaction: CommandInteraction<TextChannel>,
     user: User
 ) {

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -130,14 +130,12 @@ export class BookmarkPaginator {
                     (index + 1).toString().length > 1
                         ? `${index + 1}`
                         : `${index + 1} `
-                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                    gallery.title.pretty
-                }\``
+                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                    gallery.id
+                }) - \`${gallery.title.pretty}\``
         );
         const embeds = galleries.map((gallery, index) => {
-            const artistTags: string[] = gallery.artists.map(
-                (tag) => tag.name
-            );
+            const artistTags: string[] = gallery.artists.map((tag) => tag.name);
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
@@ -157,7 +155,11 @@ export class BookmarkPaginator {
                     : contentTags.join("`, `");
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    `https://nhentai.net/g/${gallery.id}`
+                )
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -167,16 +169,16 @@ export class BookmarkPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                gallery.title.pretty
-                            }\``,
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${gallery.title.pretty}\``,
                             `**\`🟥 ${
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                gallery.title.pretty
-                            }\`**`
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${gallery.title.pretty}\`**`
                         )
                 )
                 .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
@@ -275,17 +277,15 @@ export class BookmarkPaginator {
                     (index + 1).toString().length > 1
                         ? `${index + 1}`
                         : `${index + 1} `
-                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                    gallery.title.pretty
-                }\``
+                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                    gallery.id
+                }) - \`${gallery.title.pretty}\``
         );
 
         this.bookmarkChunks = Util.arrayToChunks(userData.bookmark, 5);
 
         const embeds = this.galleries.map((gallery, index) => {
-            const artistTags: string[] = gallery.artists.map(
-                (tag) => tag.name
-            );
+            const artistTags: string[] = gallery.artists.map((tag) => tag.name);
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
@@ -305,7 +305,11 @@ export class BookmarkPaginator {
                     : contentTags.join("`, `");
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    `https://nhentai.net/g/${gallery.id}`
+                )
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -315,16 +319,16 @@ export class BookmarkPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                gallery.title.pretty
-                            }\``,
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${gallery.title.pretty}\``,
                             `**\`🟥 ${
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                gallery.title.pretty
-                            }\`**`
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${gallery.title.pretty}\`**`
                         )
                 )
                 .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
@@ -689,10 +693,15 @@ export class BookmarkPaginator {
                     this.initialisePaginator();
                     break;
                 case `show_cover_${this.interaction.id}`:
-                    embed.setImage(this.client.api.getImageURL(
-                        (await this.api.getBook(parseInt(embed.toJSON().author.name)))
-                            .cover
-                    ));
+                    embed.setImage(
+                        this.client.api.getImageURL(
+                            (
+                                await this.api.getBook(
+                                    parseInt(embed.toJSON().author.name)
+                                )
+                            ).cover
+                        )
+                    );
                     this.interaction.editOriginal({
                         components: hideComponent,
                         embeds: [embed.toJSON()],

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -141,7 +141,7 @@ export class BookmarkPaginator {
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.map(
+            const contentTags: string[] = gallery.pureTags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
             const languageTags: string[] = gallery.languages.map(
@@ -289,7 +289,7 @@ export class BookmarkPaginator {
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.map(
+            const contentTags: string[] = gallery.pureTags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
             const languageTags: string[] = gallery.languages.map(

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -1,4 +1,4 @@
-import { Gallery } from "../API";
+import { Book } from "nhentai-api";
 import {
     CommandInteraction,
     ComponentInteraction,
@@ -37,7 +37,7 @@ export class ReadPaginator {
     /**
      * Current NHentai gallery
      */
-    gallery: Gallery;
+    gallery: Book;
 
     /**
      * Oceanic command interaction
@@ -62,14 +62,14 @@ export class ReadPaginator {
      */
     constructor(
         client: NReaderClient,
-        gallery: Gallery,
+        gallery: Book,
         interaction: CommandInteraction<TextChannel>
     ) {
         this.client = client;
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id, undefined, page.url)
+                .setAuthor(gallery.id.toString(), undefined, this.client.api.getImageURL(page))
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {
@@ -77,9 +77,9 @@ export class ReadPaginator {
                         lastIndex: gallery.pages.length,
                     })
                 )
-                .setImage(page.url)
+                .setImage(this.client.api.getImageURL(page))
                 .setTitle(gallery.title.pretty)
-                .setURL(gallery.url)
+                .setURL(`https://nhentai.net/g/${gallery.id}`)
                 .toJSON();
         });
         this.gallery = gallery;
@@ -144,13 +144,13 @@ export class ReadPaginator {
         this.client.stats.updateUserHistory(
             this.interaction.user.id,
             "read",
-            this.gallery.id
+            this.gallery.id.toString()
         );
 
         this.client.stats.logActivities(
             this.interaction.user.id,
             "read-paginator",
-            this.gallery.id,
+            this.gallery.id.toString(),
             this.embed,
             undefined,
             undefined
@@ -172,29 +172,29 @@ export class ReadPaginator {
 
         if (interaction.member.bot) return;
 
-        const artistTags: string[] = this.gallery.tags.artists.map(
+        const artistTags: string[] = this.gallery.artists.map(
             (tag) => tag.name
         );
-        const characterTags: string[] = this.gallery.tags.characters.map(
+        const characterTags: string[] = this.gallery.characters.map(
             (tag) => tag.name
         );
-        const contentTags: string[] = this.gallery.tags.tags.map(
+        const contentTags: string[] = this.gallery.tags.map(
             (tag) => `${tag.name} (${tag.count.toLocaleString()})`
         );
-        const languageTags: string[] = this.gallery.tags.languages.map(
+        const languageTags: string[] = this.gallery.languages.map(
             (tag) => tag.name.charAt(0).toUpperCase() + tag.name.slice(1)
         );
-        const parodyTags: string[] = this.gallery.tags.parodies.map(
+        const parodyTags: string[] = this.gallery.parodies.map(
             (tag) => tag.name
         );
-        const uploadedAt = `<t:${this.gallery.uploadDate.getTime() / 1000}:F>`;
+        const uploadedAt = `<t:${this.gallery.uploaded.getTime() / 1000}:F>`;
         const stringTag =
             contentTags.join("`, `").length >= 1024
                 ? `${contentTags.join("`, `").slice(0, 1010)}...`
                 : contentTags.join("`, `");
 
         const resultEmbed = new EmbedBuilder()
-            .setAuthor(this.gallery.id, undefined, this.gallery.url)
+            .setAuthor(this.gallery.id.toString(), undefined, `https://nhentai.net/g/${this.gallery.id}`)
             .setColor(this.client.config.BOT.COLOUR)
             .addField(
                 this.client.translate("main.title"),
@@ -260,8 +260,8 @@ export class ReadPaginator {
                         : this.client.translate("main.none")
                 }\``
             )
-            .setFooter(`⭐ ${this.gallery.favourites.toLocaleString()}`)
-            .setThumbnail(this.gallery.cover.url);
+            .setFooter(`⭐ ${this.gallery.favorites.toLocaleString()}`)
+            .setThumbnail(this.client.api.getImageURL(this.gallery.cover));
 
         const hideComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
@@ -316,7 +316,7 @@ export class ReadPaginator {
                     interaction.deferUpdate();
                     break;
                 case `show_cover_${this.interaction.id}`:
-                    resultEmbed.setImage(this.gallery.cover.url);
+                    resultEmbed.setImage(this.client.api.getImageURL(this.gallery.cover));
                     this.interaction.editOriginal({
                         components: hideComponent,
                         embeds: [resultEmbed.toJSON()],
@@ -627,7 +627,7 @@ export class ReadPaginator {
         this.client.stats.logActivities(
             this.interaction.user.id,
             "read-paginator",
-            this.gallery.id,
+            this.gallery.id.toString(),
             this.embed,
             undefined,
             undefined
@@ -642,7 +642,7 @@ export class ReadPaginator {
 
 export async function createReadPaginator(
     client: NReaderClient,
-    gallery: Gallery,
+    gallery: Book,
     interaction: CommandInteraction<TextChannel>
 ) {
     const paginator = new ReadPaginator(client, gallery, interaction);

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -69,7 +69,11 @@ export class ReadPaginator {
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, this.client.api.getImageURL(page))
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    this.client.api.getImageURL(page)
+                )
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {
@@ -194,7 +198,11 @@ export class ReadPaginator {
                 : contentTags.join("`, `");
 
         const resultEmbed = new EmbedBuilder()
-            .setAuthor(this.gallery.id.toString(), undefined, `https://nhentai.net/g/${this.gallery.id}`)
+            .setAuthor(
+                this.gallery.id.toString(),
+                undefined,
+                `https://nhentai.net/g/${this.gallery.id}`
+            )
             .setColor(this.client.config.BOT.COLOUR)
             .addField(
                 this.client.translate("main.title"),
@@ -316,7 +324,9 @@ export class ReadPaginator {
                     interaction.deferUpdate();
                     break;
                 case `show_cover_${this.interaction.id}`:
-                    resultEmbed.setImage(this.client.api.getImageURL(this.gallery.cover));
+                    resultEmbed.setImage(
+                        this.client.api.getImageURL(this.gallery.cover)
+                    );
                     this.interaction.editOriginal({
                         components: hideComponent,
                         embeds: [resultEmbed.toJSON()],

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -178,7 +178,7 @@ export class ReadPaginator {
         const characterTags: string[] = this.gallery.characters.map(
             (tag) => tag.name
         );
-        const contentTags: string[] = this.gallery.tags.map(
+        const contentTags: string[] = this.gallery.pureTags.map(
             (tag) => `${tag.name} (${tag.count.toLocaleString()})`
         );
         const languageTags: string[] = this.gallery.languages.map(

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -1,4 +1,4 @@
-import { Gallery } from "../API";
+import { Book } from "nhentai-api";
 import {
     CommandInteraction,
     ComponentInteraction,
@@ -39,7 +39,7 @@ export class ReadSearchPaginator {
     /**
      * Current NHentai gallery
      */
-    gallery: Gallery;
+    gallery: Book;
 
     /**
      * Oceanic command interaction
@@ -70,7 +70,7 @@ export class ReadSearchPaginator {
      */
     constructor(
         client: NReaderClient,
-        gallery: Gallery,
+        gallery: Book,
         interaction: CommandInteraction<TextChannel>,
         mainPaginator: SearchPaginator | BookmarkPaginator
     ) {
@@ -78,7 +78,7 @@ export class ReadSearchPaginator {
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id, undefined, page.url)
+                .setAuthor(gallery.id.toString(), undefined, this.client.api.getImageURL(page))
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {
@@ -86,9 +86,9 @@ export class ReadSearchPaginator {
                         lastIndex: gallery.pages.length,
                     })
                 )
-                .setImage(page.url)
+                .setImage(this.client.api.getImageURL(page))
                 .setTitle(gallery.title.pretty)
-                .setURL(gallery.url)
+                .setURL(`https://nhentai.net/g/${gallery.id}`)
                 .toJSON();
         });
         this.gallery = gallery;
@@ -154,13 +154,13 @@ export class ReadSearchPaginator {
         this.client.stats.updateUserHistory(
             this.interaction.user.id,
             "read",
-            this.gallery.id
+            this.gallery.id.toString()
         );
 
         this.client.stats.logActivities(
             this.interaction.user.id,
             "read-paginator",
-            this.gallery.id,
+            this.gallery.id.toString(),
             this.embed,
             undefined,
             undefined
@@ -478,7 +478,7 @@ export class ReadSearchPaginator {
         this.client.stats.logActivities(
             this.interaction.user.id,
             "read-paginator",
-            this.gallery.id,
+            this.gallery.id.toString(),
             this.embed,
             undefined,
             undefined
@@ -493,7 +493,7 @@ export class ReadSearchPaginator {
 
 export async function createReadSearchPaginator(
     client: NReaderClient,
-    gallery: Gallery,
+    gallery: Book,
     interaction: CommandInteraction<TextChannel>,
     mainPaginator: SearchPaginator | BookmarkPaginator
 ) {

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -78,7 +78,11 @@ export class ReadSearchPaginator {
         this.embed = 1;
         this.embeds = gallery.pages.map((page, index) => {
             return new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, this.client.api.getImageURL(page))
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    this.client.api.getImageURL(page)
+                )
                 .setColor(client.config.BOT.COLOUR)
                 .setFooter(
                     client.translate("main.page", {

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -109,7 +109,7 @@ export class SearchPaginator {
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
-            const contentTags: string[] = gallery.tags.map(
+            const contentTags: string[] = gallery.pureTags.map(
                 (tag) => `${tag.name} (${tag.count.toLocaleString()})`
             );
             const languageTags: string[] = gallery.languages.map(
@@ -765,7 +765,7 @@ export class SearchPaginator {
                                                 (tag) => tag.name
                                             );
                                         const contentTags: string[] =
-                                            gallery.tags.map(
+                                            gallery.pureTags.map(
                                                 (tag) =>
                                                     `${
                                                         tag.name
@@ -1046,7 +1046,7 @@ export class SearchPaginator {
                                                 (tag) => tag.name
                                             );
                                         const contentTags: string[] =
-                                            gallery.tags.map(
+                                            gallery.pureTags.map(
                                                 (tag) =>
                                                     `${
                                                         tag.name
@@ -1303,7 +1303,7 @@ export class SearchPaginator {
                                             (tag) => tag.name
                                         );
                                     const contentTags: string[] =
-                                        gallery.tags.map(
+                                        gallery.pureTags.map(
                                             (tag) =>
                                                 `${
                                                     tag.name
@@ -1532,7 +1532,7 @@ export class SearchPaginator {
                                             (tag) => tag.name
                                         );
                                     const contentTags: string[] =
-                                        gallery.tags.map(
+                                        gallery.pureTags.map(
                                             (tag) =>
                                                 `${
                                                     tag.name
@@ -1882,7 +1882,7 @@ export class SearchPaginator {
                                             (tag) => tag.name
                                         );
                                     const contentTags: string[] =
-                                        gallery.tags.map(
+                                        gallery.pureTags.map(
                                             (tag) =>
                                                 `${
                                                     tag.name

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -96,16 +96,16 @@ export class SearchPaginator {
                     (index + 1).toString().length > 1
                         ? `${index + 1}`
                         : `${index + 1} `
-                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                    gallery.id
+                }) - \`${
                     gallery.title.pretty.length >= 30
                         ? `${gallery.title.pretty.slice(0, 30)}...`
                         : gallery.title.pretty
                 }\``
         );
         const embeds = this.search.books.map((gallery, index) => {
-            const artistTags: string[] = gallery.artists.map(
-                (tag) => tag.name
-            );
+            const artistTags: string[] = gallery.artists.map((tag) => tag.name);
             const characterTags: string[] = gallery.characters.map(
                 (tag) => tag.name
             );
@@ -125,7 +125,11 @@ export class SearchPaginator {
                     : contentTags.join("`, `");
 
             return new EmbedBuilder()
-                .setAuthor(gallery.id.toString(), undefined, `https://nhentai.net/g/${gallery.id}`)
+                .setAuthor(
+                    gallery.id.toString(),
+                    undefined,
+                    `https://nhentai.net/g/${gallery.id}`
+                )
                 .setColor(this.client.config.BOT.COLOUR)
                 .setDescription(
                     title
@@ -135,7 +139,9 @@ export class SearchPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${
                                 gallery.title.pretty.length >= 30
                                     ? `${gallery.title.pretty.slice(0, 30)}...`
                                     : gallery.title.pretty
@@ -144,7 +150,9 @@ export class SearchPaginator {
                                 (index + 1).toString().length > 1
                                     ? `${index + 1}`
                                     : `${index + 1} `
-                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                            }\` - [\`${gallery.id}\`](https://nhentai.net/g/${
+                                gallery.id
+                            }) - \`${
                                 gallery.title.pretty.length >= 30
                                     ? `${gallery.title.pretty.slice(0, 30)}...`
                                     : gallery.title.pretty
@@ -510,10 +518,15 @@ export class SearchPaginator {
                     this.initialisePaginator();
                     break;
                 case `show_cover_${this.interaction.id}`:
-                    embed.setImage(this.client.api.getImageURL(
-                        (await this.api.getBook(parseInt(embed.toJSON().author.name)))
-                            .cover
-                    ));
+                    embed.setImage(
+                        this.client.api.getImageURL(
+                            (
+                                await this.api.getBook(
+                                    parseInt(embed.toJSON().author.name)
+                                )
+                            ).cover
+                        )
+                    );
                     this.interaction.editOriginal({
                         components: hideComponent,
                         embeds: [embed.toJSON()],
@@ -745,7 +758,11 @@ export class SearchPaginator {
                                             (index + 1).toString().length > 1
                                                 ? `${index + 1}`
                                                 : `${index + 1} `
-                                        }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                        }\` - [\`${
+                                            gallery.id
+                                        }\`](https://nhentai.net/g/${
+                                            gallery.id
+                                        }) - \`${
                                             gallery.title.pretty.length >= 30
                                                 ? `${gallery.title.pretty.slice(
                                                       0,
@@ -818,7 +835,9 @@ export class SearchPaginator {
                                                                   } `
                                                         }\` - [\`${
                                                             gallery.id
-                                                        }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                        }\`](https://nhentai.net/g/${
+                                                            gallery.id
+                                                        }) - \`${
                                                             gallery.title.pretty
                                                                 .length >= 30
                                                                 ? `${gallery.title.pretty.slice(
@@ -839,7 +858,9 @@ export class SearchPaginator {
                                                                   } `
                                                         }\` - [\`${
                                                             gallery.id
-                                                        }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                        }\`](https://nhentai.net/g/${
+                                                            gallery.id
+                                                        }) - \`${
                                                             gallery.title.pretty
                                                                 .length >= 30
                                                                 ? `${gallery.title.pretty.slice(
@@ -865,7 +886,11 @@ export class SearchPaginator {
                                                     }
                                                 )
                                             )
-                                            .setThumbnail(this.client.api.getImageURL(gallery.cover))
+                                            .setThumbnail(
+                                                this.client.api.getImageURL(
+                                                    gallery.cover
+                                                )
+                                            )
                                             .addField(
                                                 this.client.translate(
                                                     "main.title"
@@ -1026,7 +1051,11 @@ export class SearchPaginator {
                                             (index + 1).toString().length > 1
                                                 ? `${index + 1}`
                                                 : `${index + 1} `
-                                        }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                        }\` - [\`${
+                                            gallery.id
+                                        }\`](https://nhentai.net/g/${
+                                            gallery.id
+                                        }) - \`${
                                             gallery.title.pretty.length >= 30
                                                 ? `${gallery.title.pretty.slice(
                                                       0,
@@ -1099,7 +1128,9 @@ export class SearchPaginator {
                                                                   } `
                                                         }\` - [\`${
                                                             gallery.id
-                                                        }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                        }\`](https://nhentai.net/g/${
+                                                            gallery.id
+                                                        }) - \`${
                                                             gallery.title.pretty
                                                                 .length >= 30
                                                                 ? `${gallery.title.pretty.slice(
@@ -1120,7 +1151,9 @@ export class SearchPaginator {
                                                                   } `
                                                         }\` - [\`${
                                                             gallery.id
-                                                        }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                        }\`](https://nhentai.net/g/${
+                                                            gallery.id
+                                                        }) - \`${
                                                             gallery.title.pretty
                                                                 .length >= 30
                                                                 ? `${gallery.title.pretty.slice(
@@ -1146,7 +1179,11 @@ export class SearchPaginator {
                                                     }
                                                 )
                                             )
-                                            .setThumbnail(this.client.api.getImageURL(gallery.cover))
+                                            .setThumbnail(
+                                                this.client.api.getImageURL(
+                                                    gallery.cover
+                                                )
+                                            )
                                             .addField(
                                                 this.client.translate(
                                                     "main.title"
@@ -1274,237 +1311,211 @@ export class SearchPaginator {
                 case `first_result_page_${this.interaction.id}`:
                     interaction.deferUpdate();
 
-                    this.api
-                        .search(this.search.query, 1)
-                        .then((search) => {
-                            const title = search.books.map(
-                                (gallery, index) =>
-                                    `\`⬛ ${
-                                        (index + 1).toString().length > 1
-                                            ? `${index + 1}`
-                                            : `${index + 1} `
-                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                        gallery.title.pretty.length >= 30
-                                            ? `${gallery.title.pretty.slice(
-                                                  0,
-                                                  30
-                                              )}...`
-                                            : gallery.title.pretty
+                    this.api.search(this.search.query, 1).then((search) => {
+                        const title = search.books.map(
+                            (gallery, index) =>
+                                `\`⬛ ${
+                                    (index + 1).toString().length > 1
+                                        ? `${index + 1}`
+                                        : `${index + 1} `
+                                }\` - [\`${
+                                    gallery.id
+                                }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                    gallery.title.pretty.length >= 30
+                                        ? `${gallery.title.pretty.slice(
+                                              0,
+                                              30
+                                          )}...`
+                                        : gallery.title.pretty
+                                }\``
+                        );
+                        const embeds = search.books.map((gallery, index) => {
+                            const artistTags: string[] = gallery.artists.map(
+                                (tag) => tag.name
+                            );
+                            const characterTags: string[] =
+                                gallery.characters.map((tag) => tag.name);
+                            const contentTags: string[] = gallery.pureTags.map(
+                                (tag) =>
+                                    `${
+                                        tag.name
+                                    } (${tag.count.toLocaleString()})`
+                            );
+                            const languageTags: string[] =
+                                gallery.languages.map(
+                                    (tag) =>
+                                        tag.name.charAt(0).toUpperCase() +
+                                        tag.name.slice(1)
+                                );
+                            const parodyTags: string[] = gallery.parodies.map(
+                                (tag) => tag.name
+                            );
+                            const uploadedAt = `<t:${
+                                gallery.uploaded.getTime() / 1000
+                            }:F>`;
+                            const stringTag =
+                                contentTags.join("`, `").length >= 1024
+                                    ? `${contentTags
+                                          .join("`, `")
+                                          .slice(0, 1010)}...`
+                                    : contentTags.join("`, `");
+
+                            return new EmbedBuilder()
+                                .setAuthor(
+                                    gallery.id.toString(),
+                                    undefined,
+                                    `https://nhentai.net/g/${gallery.id}`
+                                )
+                                .setColor(this.client.config.BOT.COLOUR)
+                                .setDescription(
+                                    title
+                                        .join("\n")
+                                        .replace(
+                                            `\`⬛ ${
+                                                (index + 1).toString().length >
+                                                1
+                                                    ? `${index + 1}`
+                                                    : `${index + 1} `
+                                            }\` - [\`${
+                                                gallery.id
+                                            }\`](https://nhentai.net/g/${
+                                                gallery.id
+                                            }) - \`${
+                                                gallery.title.pretty.length >=
+                                                30
+                                                    ? `${gallery.title.pretty.slice(
+                                                          0,
+                                                          30
+                                                      )}...`
+                                                    : gallery.title.pretty
+                                            }\``,
+                                            `**\`🟥 ${
+                                                (index + 1).toString().length >
+                                                1
+                                                    ? `${index + 1}`
+                                                    : `${index + 1} `
+                                            }\` - [\`${
+                                                gallery.id
+                                            }\`](https://nhentai.net/g/${
+                                                gallery.id
+                                            }) - \`${
+                                                gallery.title.pretty.length >=
+                                                30
+                                                    ? `${gallery.title.pretty.slice(
+                                                          0,
+                                                          30
+                                                      )}...`
+                                                    : gallery.title.pretty
+                                            }\`**`
+                                        )
+                                )
+                                .setFooter(
+                                    `⭐ ${gallery.favorites.toLocaleString()}`
+                                )
+                                .setTitle(
+                                    this.client.translate("main.page", {
+                                        firstIndex:
+                                            search.page.toLocaleString(),
+                                        lastIndex:
+                                            search.pages.toLocaleString(),
+                                    })
+                                )
+                                .setThumbnail(
+                                    this.client.api.getImageURL(gallery.cover)
+                                )
+                                .addField(
+                                    this.client.translate("main.title"),
+                                    `\`${gallery.title.pretty}\``
+                                )
+                                .addField(
+                                    this.client.translate("main.pages"),
+                                    `\`${gallery.pages.length}\``
+                                )
+                                .addField(
+                                    this.client.translate("main.released"),
+                                    uploadedAt
+                                )
+                                .addField(
+                                    languageTags.length > 1
+                                        ? this.client.translate(
+                                              "main.languages"
+                                          )
+                                        : this.client.translate(
+                                              "main.language"
+                                          ),
+                                    `\`${
+                                        languageTags.length !== 0
+                                            ? languageTags.join("`, `")
+                                            : this.client.translate("main.none")
                                     }\``
-                            );
-                            const embeds = search.books.map(
-                                (gallery, index) => {
-                                    const artistTags: string[] =
-                                        gallery.artists.map(
-                                            (tag) => tag.name
-                                        );
-                                    const characterTags: string[] =
-                                        gallery.characters.map(
-                                            (tag) => tag.name
-                                        );
-                                    const contentTags: string[] =
-                                        gallery.pureTags.map(
-                                            (tag) =>
-                                                `${
-                                                    tag.name
-                                                } (${tag.count.toLocaleString()})`
-                                        );
-                                    const languageTags: string[] =
-                                        gallery.languages.map(
-                                            (tag) =>
-                                                tag.name
-                                                    .charAt(0)
-                                                    .toUpperCase() +
-                                                tag.name.slice(1)
-                                        );
-                                    const parodyTags: string[] =
-                                        gallery.parodies.map(
-                                            (tag) => tag.name
-                                        );
-                                    const uploadedAt = `<t:${
-                                        gallery.uploaded.getTime() / 1000
-                                    }:F>`;
-                                    const stringTag =
-                                        contentTags.join("`, `").length >= 1024
-                                            ? `${contentTags
+                                )
+                                .addField(
+                                    artistTags.length > 1
+                                        ? this.client.translate("main.artists")
+                                        : this.client.translate("main.artist"),
+                                    `\`${
+                                        artistTags.length !== 0
+                                            ? artistTags.join("`, `")
+                                            : this.client.translate("main.none")
+                                    }\``
+                                )
+                                .addField(
+                                    characterTags.length > 1
+                                        ? this.client.translate(
+                                              "main.characters"
+                                          )
+                                        : this.client.translate(
+                                              "main.character"
+                                          ),
+                                    `\`${
+                                        characterTags.length !== 0
+                                            ? characterTags.join("`, `")
+                                            : this.client.translate(
+                                                  "main.original"
+                                              )
+                                    }\``
+                                )
+                                .addField(
+                                    parodyTags.length > 1
+                                        ? this.client.translate("main.parodies")
+                                        : this.client.translate("main.parody"),
+                                    `\`${
+                                        parodyTags.length !== 0
+                                            ? parodyTags
                                                   .join("`, `")
-                                                  .slice(0, 1010)}...`
-                                            : contentTags.join("`, `");
-
-                                    return new EmbedBuilder()
-                                        .setAuthor(
-                                            gallery.id.toString(),
-                                            undefined,
-                                            `https://nhentai.net/g/${gallery.id}`
-                                        )
-                                        .setColor(this.client.config.BOT.COLOUR)
-                                        .setDescription(
-                                            title
-                                                .join("\n")
-                                                .replace(
-                                                    `\`⬛ ${
-                                                        (index + 1).toString()
-                                                            .length > 1
-                                                            ? `${index + 1}`
-                                                            : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                                        gallery.title.pretty
-                                                            .length >= 30
-                                                            ? `${gallery.title.pretty.slice(
-                                                                  0,
-                                                                  30
-                                                              )}...`
-                                                            : gallery.title
-                                                                  .pretty
-                                                    }\``,
-                                                    `**\`🟥 ${
-                                                        (index + 1).toString()
-                                                            .length > 1
-                                                            ? `${index + 1}`
-                                                            : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                                        gallery.title.pretty
-                                                            .length >= 30
-                                                            ? `${gallery.title.pretty.slice(
-                                                                  0,
-                                                                  30
-                                                              )}...`
-                                                            : gallery.title
-                                                                  .pretty
-                                                    }\`**`
-                                                )
-                                        )
-                                        .setFooter(
-                                            `⭐ ${gallery.favorites.toLocaleString()}`
-                                        )
-                                        .setTitle(
-                                            this.client.translate("main.page", {
-                                                firstIndex:
-                                                    search.page.toLocaleString(),
-                                                lastIndex:
-                                                    search.pages.toLocaleString(),
-                                            })
-                                        )
-                                        .setThumbnail(this.client.api.getImageURL(gallery.cover))
-                                        .addField(
-                                            this.client.translate("main.title"),
-                                            `\`${gallery.title.pretty}\``
-                                        )
-                                        .addField(
-                                            this.client.translate("main.pages"),
-                                            `\`${gallery.pages.length}\``
-                                        )
-                                        .addField(
-                                            this.client.translate(
-                                                "main.released"
-                                            ),
-                                            uploadedAt
-                                        )
-                                        .addField(
-                                            languageTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.languages"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.language"
-                                                  ),
-                                            `\`${
-                                                languageTags.length !== 0
-                                                    ? languageTags.join("`, `")
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            artistTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.artists"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.artist"
-                                                  ),
-                                            `\`${
-                                                artistTags.length !== 0
-                                                    ? artistTags.join("`, `")
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            characterTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.characters"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.character"
-                                                  ),
-                                            `\`${
-                                                characterTags.length !== 0
-                                                    ? characterTags.join("`, `")
-                                                    : this.client.translate(
+                                                  .replace(
+                                                      "original",
+                                                      `${this.client.translate(
                                                           "main.original"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            parodyTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.parodies"
+                                                      )}`
                                                   )
-                                                : this.client.translate(
-                                                      "main.parody"
-                                                  ),
-                                            `\`${
-                                                parodyTags.length !== 0
-                                                    ? parodyTags
-                                                          .join("`, `")
-                                                          .replace(
-                                                              "original",
-                                                              `${this.client.translate(
-                                                                  "main.original"
-                                                              )}`
-                                                          )
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            contentTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.tags"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.tag"
-                                                  ),
-                                            `\`${
-                                                contentTags.length !== 0
-                                                    ? stringTag
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        );
-                                }
-                            );
-
-                            this.search = search;
-                            this.embeds = embeds.map((embed) => embed.toJSON());
-                            this.embed = 1;
-                            this.updatePaginator();
+                                            : this.client.translate("main.none")
+                                    }\``
+                                )
+                                .addField(
+                                    contentTags.length > 1
+                                        ? this.client.translate("main.tags")
+                                        : this.client.translate("main.tag"),
+                                    `\`${
+                                        contentTags.length !== 0
+                                            ? stringTag
+                                            : this.client.translate("main.none")
+                                    }\``
+                                );
                         });
+
+                        this.search = search;
+                        this.embeds = embeds.map((embed) => embed.toJSON());
+                        this.embed = 1;
+                        this.updatePaginator();
+                    });
 
                     break;
                 case `last_result_page_${this.interaction.id}`:
                     interaction.deferUpdate();
 
                     this.api
-                        .search(
-                            this.search.query,
-                            this.search.pages
-                        )
+                        .search(this.search.query, this.search.pages)
                         .then((search) => {
                             const title = search.books.map(
                                 (gallery, index) =>
@@ -1512,7 +1523,11 @@ export class SearchPaginator {
                                         (index + 1).toString().length > 1
                                             ? `${index + 1}`
                                             : `${index + 1} `
-                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                    }\` - [\`${
+                                        gallery.id
+                                    }\`](https://nhentai.net/g/${
+                                        gallery.id
+                                    }) - \`${
                                         gallery.title.pretty.length >= 30
                                             ? `${gallery.title.pretty.slice(
                                                   0,
@@ -1524,9 +1539,7 @@ export class SearchPaginator {
                             const embeds = search.books.map(
                                 (gallery, index) => {
                                     const artistTags: string[] =
-                                        gallery.artists.map(
-                                            (tag) => tag.name
-                                        );
+                                        gallery.artists.map((tag) => tag.name);
                                     const characterTags: string[] =
                                         gallery.characters.map(
                                             (tag) => tag.name
@@ -1547,9 +1560,7 @@ export class SearchPaginator {
                                                 tag.name.slice(1)
                                         );
                                     const parodyTags: string[] =
-                                        gallery.parodies.map(
-                                            (tag) => tag.name
-                                        );
+                                        gallery.parodies.map((tag) => tag.name);
                                     const uploadedAt = `<t:${
                                         gallery.uploaded.getTime() / 1000
                                     }:F>`;
@@ -1576,7 +1587,11 @@ export class SearchPaginator {
                                                             .length > 1
                                                             ? `${index + 1}`
                                                             : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                    }\` - [\`${
+                                                        gallery.id
+                                                    }\`](https://nhentai.net/g/${
+                                                        gallery.id
+                                                    }) - \`${
                                                         gallery.title.pretty
                                                             .length >= 30
                                                             ? `${gallery.title.pretty.slice(
@@ -1591,7 +1606,11 @@ export class SearchPaginator {
                                                             .length > 1
                                                             ? `${index + 1}`
                                                             : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                                    }\` - [\`${
+                                                        gallery.id
+                                                    }\`](https://nhentai.net/g/${
+                                                        gallery.id
+                                                    }) - \`${
                                                         gallery.title.pretty
                                                             .length >= 30
                                                             ? `${gallery.title.pretty.slice(
@@ -1614,7 +1633,11 @@ export class SearchPaginator {
                                                     search.pages.toLocaleString(),
                                             })
                                         )
-                                        .setThumbnail(this.client.api.getImageURL(gallery.cover))
+                                        .setThumbnail(
+                                            this.client.api.getImageURL(
+                                                gallery.cover
+                                            )
+                                        )
                                         .addField(
                                             this.client.translate("main.title"),
                                             `\`${gallery.title.pretty}\``
@@ -1853,227 +1876,204 @@ export class SearchPaginator {
                         });
                     }
 
-                    this.api
-                        .search(this.search.query, page)
-                        .then((search) => {
-                            const title = search.books.map(
-                                (gallery, index) =>
-                                    `\`⬛ ${
-                                        (index + 1).toString().length > 1
-                                            ? `${index + 1}`
-                                            : `${index + 1} `
-                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                        gallery.title.pretty.length >= 30
-                                            ? `${gallery.title.pretty.slice(
-                                                  0,
-                                                  30
-                                              )}...`
-                                            : gallery.title.pretty
+                    this.api.search(this.search.query, page).then((search) => {
+                        const title = search.books.map(
+                            (gallery, index) =>
+                                `\`⬛ ${
+                                    (index + 1).toString().length > 1
+                                        ? `${index + 1}`
+                                        : `${index + 1} `
+                                }\` - [\`${
+                                    gallery.id
+                                }\`](https://nhentai.net/g/${gallery.id}) - \`${
+                                    gallery.title.pretty.length >= 30
+                                        ? `${gallery.title.pretty.slice(
+                                              0,
+                                              30
+                                          )}...`
+                                        : gallery.title.pretty
+                                }\``
+                        );
+                        const embeds = search.books.map((gallery, index) => {
+                            const artistTags: string[] = gallery.artists.map(
+                                (tag) => tag.name
+                            );
+                            const characterTags: string[] =
+                                gallery.characters.map((tag) => tag.name);
+                            const contentTags: string[] = gallery.pureTags.map(
+                                (tag) =>
+                                    `${
+                                        tag.name
+                                    } (${tag.count.toLocaleString()})`
+                            );
+                            const languageTags: string[] =
+                                gallery.languages.map(
+                                    (tag) =>
+                                        tag.name.charAt(0).toUpperCase() +
+                                        tag.name.slice(1)
+                                );
+                            const parodyTags: string[] = gallery.parodies.map(
+                                (tag) => tag.name
+                            );
+                            const uploadedAt = `<t:${
+                                gallery.uploaded.getTime() / 1000
+                            }:F>`;
+                            const stringTag =
+                                contentTags.join("`, `").length >= 1024
+                                    ? `${contentTags
+                                          .join("`, `")
+                                          .slice(0, 1010)}...`
+                                    : contentTags.join("`, `");
+
+                            return new EmbedBuilder()
+                                .setAuthor(
+                                    gallery.id.toString(),
+                                    undefined,
+                                    `https://nhentai.net/g/${gallery.id}`
+                                )
+                                .setColor(this.client.config.BOT.COLOUR)
+                                .setDescription(
+                                    title
+                                        .join("\n")
+                                        .replace(
+                                            `\`⬛ ${
+                                                (index + 1).toString().length >
+                                                1
+                                                    ? `${index + 1}`
+                                                    : `${index + 1} `
+                                            }\` - [\`${
+                                                gallery.id
+                                            }\`](https://nhentai.net/g/${
+                                                gallery.id
+                                            }) - \`${
+                                                gallery.title.pretty.length >=
+                                                30
+                                                    ? `${gallery.title.pretty.slice(
+                                                          0,
+                                                          30
+                                                      )}...`
+                                                    : gallery.title.pretty
+                                            }\``,
+                                            `**\`🟥 ${
+                                                (index + 1).toString().length >
+                                                1
+                                                    ? `${index + 1}`
+                                                    : `${index + 1} `
+                                            }\` - [\`${
+                                                gallery.id
+                                            }\`](https://nhentai.net/g/${
+                                                gallery.id
+                                            }) - \`${
+                                                gallery.title.pretty.length >=
+                                                30
+                                                    ? `${gallery.title.pretty.slice(
+                                                          0,
+                                                          30
+                                                      )}...`
+                                                    : gallery.title.pretty
+                                            }\`**`
+                                        )
+                                )
+                                .setFooter(
+                                    `⭐ ${gallery.favorites.toLocaleString()}`
+                                )
+                                .setTitle(
+                                    this.client.translate("main.page", {
+                                        firstIndex:
+                                            search.page.toLocaleString(),
+                                        lastIndex:
+                                            search.pages.toLocaleString(),
+                                    })
+                                )
+                                .setThumbnail(
+                                    this.client.api.getImageURL(gallery.cover)
+                                )
+                                .addField(
+                                    this.client.translate("main.title"),
+                                    `\`${gallery.title.pretty}\``
+                                )
+                                .addField(
+                                    this.client.translate("main.pages"),
+                                    `\`${gallery.pages.length}\``
+                                )
+                                .addField(
+                                    this.client.translate("main.released"),
+                                    uploadedAt
+                                )
+                                .addField(
+                                    languageTags.length > 1
+                                        ? this.client.translate(
+                                              "main.languages"
+                                          )
+                                        : this.client.translate(
+                                              "main.language"
+                                          ),
+                                    `\`${
+                                        languageTags.length !== 0
+                                            ? languageTags.join("`, `")
+                                            : this.client.translate("main.none")
                                     }\``
-                            );
-                            const embeds = search.books.map(
-                                (gallery, index) => {
-                                    const artistTags: string[] =
-                                        gallery.artists.map(
-                                            (tag) => tag.name
-                                        );
-                                    const characterTags: string[] =
-                                        gallery.characters.map(
-                                            (tag) => tag.name
-                                        );
-                                    const contentTags: string[] =
-                                        gallery.pureTags.map(
-                                            (tag) =>
-                                                `${
-                                                    tag.name
-                                                } (${tag.count.toLocaleString()})`
-                                        );
-                                    const languageTags: string[] =
-                                        gallery.languages.map(
-                                            (tag) =>
-                                                tag.name
-                                                    .charAt(0)
-                                                    .toUpperCase() +
-                                                tag.name.slice(1)
-                                        );
-                                    const parodyTags: string[] =
-                                        gallery.parodies.map(
-                                            (tag) => tag.name
-                                        );
-                                    const uploadedAt = `<t:${
-                                        gallery.uploaded.getTime() / 1000
-                                    }:F>`;
-                                    const stringTag =
-                                        contentTags.join("`, `").length >= 1024
-                                            ? `${contentTags
+                                )
+                                .addField(
+                                    artistTags.length > 1
+                                        ? this.client.translate("main.artists")
+                                        : this.client.translate("main.artist"),
+                                    `\`${
+                                        artistTags.length !== 0
+                                            ? artistTags.join("`, `")
+                                            : this.client.translate("main.none")
+                                    }\``
+                                )
+                                .addField(
+                                    characterTags.length > 1
+                                        ? this.client.translate(
+                                              "main.characters"
+                                          )
+                                        : this.client.translate(
+                                              "main.character"
+                                          ),
+                                    `\`${
+                                        characterTags.length !== 0
+                                            ? characterTags.join("`, `")
+                                            : this.client.translate(
+                                                  "main.original"
+                                              )
+                                    }\``
+                                )
+                                .addField(
+                                    parodyTags.length > 1
+                                        ? this.client.translate("main.parodies")
+                                        : this.client.translate("main.parody"),
+                                    `\`${
+                                        parodyTags.length !== 0
+                                            ? parodyTags
                                                   .join("`, `")
-                                                  .slice(0, 1010)}...`
-                                            : contentTags.join("`, `");
-
-                                    return new EmbedBuilder()
-                                        .setAuthor(
-                                            gallery.id.toString(),
-                                            undefined,
-                                            `https://nhentai.net/g/${gallery.id}`
-                                        )
-                                        .setColor(this.client.config.BOT.COLOUR)
-                                        .setDescription(
-                                            title
-                                                .join("\n")
-                                                .replace(
-                                                    `\`⬛ ${
-                                                        (index + 1).toString()
-                                                            .length > 1
-                                                            ? `${index + 1}`
-                                                            : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                                        gallery.title.pretty
-                                                            .length >= 30
-                                                            ? `${gallery.title.pretty.slice(
-                                                                  0,
-                                                                  30
-                                                              )}...`
-                                                            : gallery.title
-                                                                  .pretty
-                                                    }\``,
-                                                    `**\`🟥 ${
-                                                        (index + 1).toString()
-                                                            .length > 1
-                                                            ? `${index + 1}`
-                                                            : `${index + 1} `
-                                                    }\` - [\`${gallery.id}\`](https://nhentai.net/g/${gallery.id}) - \`${
-                                                        gallery.title.pretty
-                                                            .length >= 30
-                                                            ? `${gallery.title.pretty.slice(
-                                                                  0,
-                                                                  30
-                                                              )}...`
-                                                            : gallery.title
-                                                                  .pretty
-                                                    }\`**`
-                                                )
-                                        )
-                                        .setFooter(
-                                            `⭐ ${gallery.favorites.toLocaleString()}`
-                                        )
-                                        .setTitle(
-                                            this.client.translate("main.page", {
-                                                firstIndex:
-                                                    search.page.toLocaleString(),
-                                                lastIndex:
-                                                    search.pages.toLocaleString(),
-                                            })
-                                        )
-                                        .setThumbnail(this.client.api.getImageURL(gallery.cover))
-                                        .addField(
-                                            this.client.translate("main.title"),
-                                            `\`${gallery.title.pretty}\``
-                                        )
-                                        .addField(
-                                            this.client.translate("main.pages"),
-                                            `\`${gallery.pages.length}\``
-                                        )
-                                        .addField(
-                                            this.client.translate(
-                                                "main.released"
-                                            ),
-                                            uploadedAt
-                                        )
-                                        .addField(
-                                            languageTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.languages"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.language"
-                                                  ),
-                                            `\`${
-                                                languageTags.length !== 0
-                                                    ? languageTags.join("`, `")
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            artistTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.artists"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.artist"
-                                                  ),
-                                            `\`${
-                                                artistTags.length !== 0
-                                                    ? artistTags.join("`, `")
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            characterTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.characters"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.character"
-                                                  ),
-                                            `\`${
-                                                characterTags.length !== 0
-                                                    ? characterTags.join("`, `")
-                                                    : this.client.translate(
+                                                  .replace(
+                                                      "original",
+                                                      `${this.client.translate(
                                                           "main.original"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            parodyTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.parodies"
+                                                      )}`
                                                   )
-                                                : this.client.translate(
-                                                      "main.parody"
-                                                  ),
-                                            `\`${
-                                                parodyTags.length !== 0
-                                                    ? parodyTags
-                                                          .join("`, `")
-                                                          .replace(
-                                                              "original",
-                                                              `${this.client.translate(
-                                                                  "main.original"
-                                                              )}`
-                                                          )
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        )
-                                        .addField(
-                                            contentTags.length > 1
-                                                ? this.client.translate(
-                                                      "main.tags"
-                                                  )
-                                                : this.client.translate(
-                                                      "main.tag"
-                                                  ),
-                                            `\`${
-                                                contentTags.length !== 0
-                                                    ? stringTag
-                                                    : this.client.translate(
-                                                          "main.none"
-                                                      )
-                                            }\``
-                                        );
-                                }
-                            );
-
-                            this.search = search;
-                            this.embeds = embeds.map((embed) => embed.toJSON());
-                            this.embed = 1;
-                            this.updatePaginator();
+                                            : this.client.translate("main.none")
+                                    }\``
+                                )
+                                .addField(
+                                    contentTags.length > 1
+                                        ? this.client.translate("main.tags")
+                                        : this.client.translate("main.tag"),
+                                    `\`${
+                                        contentTags.length !== 0
+                                            ? stringTag
+                                            : this.client.translate("main.none")
+                                    }\``
+                                );
                         });
+
+                        this.search = search;
+                        this.embeds = embeds.map((embed) => embed.toJSON());
+                        this.embed = 1;
+                        this.updatePaginator();
+                    });
 
                     interaction.deferUpdate();
                     break;

--- a/framework/lib/Modules/StatsManager.ts
+++ b/framework/lib/Modules/StatsManager.ts
@@ -96,7 +96,7 @@ export class StatsManager {
         if (type === "bookmarked") {
             this.client.logger.log({
                 color: "#CC8899",
-                message: `${user.tag} (${user.id}) ${
+                message: `${user.username} (${user.id}) ${
                     action.charAt(0).toUpperCase() + action.slice(1)
                 } "${query}" ${
                     action === "added" ? "To" : "From"
@@ -117,8 +117,8 @@ export class StatsManager {
                 color: "#CC8899",
                 message:
                     typeof query !== "undefined"
-                        ? `${user.tag} (${user.id}): "${query}"`
-                        : `${user.tag} (${user.id})`,
+                        ? `${user.username} (${user.id}): "${query}"`
+                        : `${user.username} (${user.id})`,
                 subTitle: "NReaderFramework::Logging::Activities",
                 title: type.toUpperCase(),
                 type: "ACTIVITIES",
@@ -132,7 +132,7 @@ export class StatsManager {
         ) {
             this.client.logger.log({
                 color: "#CC8899",
-                message: `${user.tag} (${user.id}): "${query}" | ${
+                message: `${user.username} (${user.id}): "${query}" | ${
                     type === "bookmark-paginator" || type === "search-paginator"
                         ? `Page: ${page} | Result: ${result} | ID: ${queryID}`
                         : `Page: ${page}`

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -12,18 +12,22 @@
         "@oceanicjs/builders": "^1.0.2",
         "byte-size": "^8.1.0",
         "chalk": "^4.1.2",
+        "http-cookie-agent": "^5.0.4",
         "i18next": "^21.8.13",
         "i18next-icu": "^2.0.3",
         "moment": "^2.29.4",
         "mongoose": "^6.0.12",
+        "nhentai-api": "^3.4.3",
         "node-fetch": "^2.6.7",
         "oceanic.js": "^1.5.1",
-        "os-utils": "^0.0.14"
+        "os-utils": "^0.0.14",
+        "tough-cookie": "^4.1.3"
       },
       "devDependencies": {
         "@types/byte-size": "^8.1.0",
         "@types/node-fetch": "^2.6.2",
         "@types/os-utils": "^0.0.1",
+        "@types/tough-cookie": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "eslint": "^8.11.0",
@@ -305,6 +309,12 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
@@ -540,6 +550,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1451,6 +1472,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-5.0.4.tgz",
+      "integrity": "sha512-OtvikW69RvfyP6Lsequ0fN5R49S+8QcS9zwd58k6VSr6r57T8G29BkPdyrBcSwLq6ExLs9V+rBlfxu7gDstJag==",
+      "dependencies": {
+        "agent-base": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=14.18.0 <15.0.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "deasync": "^0.1.26",
+        "tough-cookie": "^4.0.0",
+        "undici": "^5.11.0"
+      },
+      "peerDependenciesMeta": {
+        "deasync": {
+          "optional": true
+        },
+        "undici": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/i18next": {
       "version": "21.8.13",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.8.13.tgz",
@@ -1862,6 +1910,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/nhentai-api": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/nhentai-api/-/nhentai-api-3.4.3.tgz",
+      "integrity": "sha512-IPzoB9/GRVF/wofyao6SfpFIak2GyE8+4F7ipDJXK/vmxV3QPa+7E7+cst2zsXis5j9Yxk3Cf/zodktaM9UU9w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -2065,6 +2121,11 @@
         }
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2072,6 +2133,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2130,6 +2196,11 @@
       "engines": {
         "node": ">=0.10.5"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -2399,6 +2470,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -2629,6 +2714,14 @@
         "node": ">=12.18"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2636,6 +2729,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -2982,6 +3084,12 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
     "@types/webidl-conversions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
@@ -3118,6 +3226,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -3791,6 +3907,14 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
+    "http-cookie-agent": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-5.0.4.tgz",
+      "integrity": "sha512-OtvikW69RvfyP6Lsequ0fN5R49S+8QcS9zwd58k6VSr6r57T8G29BkPdyrBcSwLq6ExLs9V+rBlfxu7gDstJag==",
+      "requires": {
+        "agent-base": "^7.1.0"
+      }
+    },
     "i18next": {
       "version": "21.8.13",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.8.13.tgz",
@@ -4096,6 +4220,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "nhentai-api": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/nhentai-api/-/nhentai-api-3.4.3.tgz",
+      "integrity": "sha512-IPzoB9/GRVF/wofyao6SfpFIak2GyE8+4F7ipDJXK/vmxV3QPa+7E7+cst2zsXis5j9Yxk3Cf/zodktaM9UU9w=="
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -4227,10 +4356,20 @@
       "optional": true,
       "requires": {}
     },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -4263,6 +4402,11 @@
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -4443,6 +4587,17 @@
         "is-number": "^7.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      }
+    },
     "tr46": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -4592,6 +4747,11 @@
         "busboy": "^1.6.0"
       }
     },
+    "universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4599,6 +4759,15 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "v8-compile-cache": {

--- a/framework/package.json
+++ b/framework/package.json
@@ -23,6 +23,7 @@
     "@types/byte-size": "^8.1.0",
     "@types/node-fetch": "^2.6.2",
     "@types/os-utils": "^0.0.1",
+    "@types/tough-cookie": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "eslint": "^8.11.0",
@@ -39,12 +40,15 @@
     "@oceanicjs/builders": "^1.0.2",
     "byte-size": "^8.1.0",
     "chalk": "^4.1.2",
+    "http-cookie-agent": "^5.0.4",
     "i18next": "^21.8.13",
     "i18next-icu": "^2.0.3",
     "moment": "^2.29.4",
     "mongoose": "^6.0.12",
+    "nhentai-api": "^3.4.3",
     "node-fetch": "^2.6.7",
     "oceanic.js": "^1.5.1",
-    "os-utils": "^0.0.14"
+    "os-utils": "^0.0.14",
+    "tough-cookie": "^4.1.3"
   }
 }


### PR DESCRIPTION
This workaround has been used since the beginning. Unfortunately, we had to bring it back due to the malfunction of the IP address to bypass their direct API endpoints, which had Cloudflare DDoS protection enabled.

Unlike the previous version, we also had to use a third-party library for its cookie agent feature. I'm too lazy to write one. Until I can find a stable resolution to this, this temporary fix will be implemented. It's better than having everything shattered into pieces.