### PR TITLE
Rewrite buttons structure

### DIFF
--- a/framework/lib/Commands/Modules/BookmarkCommand.ts
+++ b/framework/lib/Commands/Modules/BookmarkCommand.ts
@@ -119,7 +119,11 @@ export async function bookmarkCommand(
             .addInteractionButton(
                 Constants.ButtonStyles.DANGER,
                 `stop_result_${interaction.id}`,
-                client.translate("main.stop")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .toJSON();
 

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -135,21 +135,21 @@ export async function readCommand(
                     }
                 )
                 .addInteractionButton(
-                    Constants.ButtonStyles.DANGER,
-                    `stop_${interaction.id}`,
-                    undefined,
-                    {
-                        id: undefined,
-                        name: "🗑",
-                    }
-                )
-                .addInteractionButton(
                     Constants.ButtonStyles.SECONDARY,
                     `bookmark_${interaction.id}`,
                     undefined,
                     {
                         id: undefined,
                         name: "🔖",
+                    }
+                )
+                .addInteractionButton(
+                    Constants.ButtonStyles.DANGER,
+                    `stop_${interaction.id}`,
+                    undefined,
+                    {
+                        id: undefined,
+                        name: "🗑",
                     }
                 )
                 .addInteractionButton(

--- a/framework/lib/Commands/Modules/ReadCommand.ts
+++ b/framework/lib/Commands/Modules/ReadCommand.ts
@@ -128,17 +128,29 @@ export async function readCommand(
                 .addInteractionButton(
                     Constants.ButtonStyles.PRIMARY,
                     `read_${interaction.id}`,
-                    client.translate("main.read")
+                    undefined,
+                    {
+                        id: undefined,
+                        name: "📖",
+                    }
                 )
                 .addInteractionButton(
                     Constants.ButtonStyles.DANGER,
                     `stop_${interaction.id}`,
-                    client.translate("main.stop")
+                    undefined,
+                    {
+                        id: undefined,
+                        name: "🗑",
+                    }
                 )
                 .addInteractionButton(
                     Constants.ButtonStyles.SECONDARY,
                     `bookmark_${interaction.id}`,
-                    client.translate("main.bookmark")
+                    undefined,
+                    {
+                        id: undefined,
+                        name: "🔖",
+                    }
                 )
                 .addInteractionButton(
                     Constants.ButtonStyles.PRIMARY,

--- a/framework/lib/Commands/Modules/SearchCommand.ts
+++ b/framework/lib/Commands/Modules/SearchCommand.ts
@@ -81,7 +81,11 @@ export async function searchCommand(
                 .addInteractionButton(
                     Constants.ButtonStyles.DANGER,
                     `stop_result_${interaction.id}`,
-                    client.translate("main.stop")
+                    undefined,
+                    {
+                        id: undefined,
+                        name: "🗑",
+                    }
                 )
                 .toJSON();
 

--- a/framework/lib/Modules/BookmarkPaginator.ts
+++ b/framework/lib/Modules/BookmarkPaginator.ts
@@ -412,72 +412,83 @@ export class BookmarkPaginator {
 
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.page.toLocaleString()} / ${this.bookmarkChunks.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -507,6 +518,9 @@ export class BookmarkPaginator {
         const userData: IUserSchema = await UserModel.findOne({
             id: interaction.user.id,
         });
+        const targetUserData: IUserSchema = await UserModel.findOne({
+            id: this.user.id,
+        });
 
         if (interaction.member.bot) return;
 
@@ -517,74 +531,87 @@ export class BookmarkPaginator {
                 : undefined
         );
 
+        this.bookmarkChunks = Util.arrayToChunks(targetUserData.bookmark, 5);
+
         const hideComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.page.toLocaleString()} / ${this.bookmarkChunks.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -595,72 +622,83 @@ export class BookmarkPaginator {
 
         const showComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.page.toLocaleString()} / ${this.bookmarkChunks.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -1088,72 +1126,83 @@ export class BookmarkPaginator {
     public updatePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.page.toLocaleString()} / ${this.bookmarkChunks.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -119,12 +119,12 @@ export class ReadPaginator {
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
+                Constants.ButtonStyles.PRIMARY,
+                `home_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🗑",
+                    name: "🏠",
                 }
             )
             .addInteractionButton(
@@ -137,12 +137,12 @@ export class ReadPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `home_${this.interaction.id}`,
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🏠",
+                    name: "🗑",
                 }
             )
             .toJSON();
@@ -289,21 +289,21 @@ export class ReadPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                undefined,
-                {
-                    id: undefined,
-                    name: "🗑",
-                }
-            )
-            .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
                     name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
                 }
             )
             .addInteractionButton(
@@ -324,21 +324,21 @@ export class ReadPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                undefined,
-                {
-                    id: undefined,
-                    name: "🗑",
-                }
-            )
-            .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
                     name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
                 }
             )
             .addInteractionButton(
@@ -649,12 +649,12 @@ export class ReadPaginator {
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
+                Constants.ButtonStyles.PRIMARY,
+                `home_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🗑",
+                    name: "🏠",
                 }
             )
             .addInteractionButton(
@@ -667,12 +667,12 @@ export class ReadPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `home_${this.interaction.id}`,
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🏠",
+                    name: "🗑",
                 }
             )
             .toJSON();

--- a/framework/lib/Modules/ReadPaginator.ts
+++ b/framework/lib/Modules/ReadPaginator.ts
@@ -67,7 +67,7 @@ export class ReadPaginator {
     ) {
         this.client = client;
         this.embed = 1;
-        this.embeds = gallery.pages.map((page, index) => {
+        this.embeds = gallery.pages.map((page) => {
             return new EmbedBuilder()
                 .setAuthor(
                     gallery.id.toString(),
@@ -75,12 +75,7 @@ export class ReadPaginator {
                     this.client.api.getImageURL(page)
                 )
                 .setColor(client.config.BOT.COLOUR)
-                .setFooter(
-                    client.translate("main.page", {
-                        firstIndex: index + 1,
-                        lastIndex: gallery.pages.length,
-                    })
-                )
+                .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
                 .setImage(this.client.api.getImageURL(page))
                 .setTitle(gallery.title.pretty)
                 .setURL(`https://nhentai.net/g/${gallery.id}`)
@@ -98,45 +93,57 @@ export class ReadPaginator {
     public async initialisePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_page_${this.interaction.id}`,
+                `${this.embed} / ${this.embeds.length}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `home_${this.interaction.id}`,
-                this.client.translate("main.home")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🏠",
+                }
             )
             .toJSON();
 
@@ -275,17 +282,29 @@ export class ReadPaginator {
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `read_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.DANGER,
                 `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -298,17 +317,29 @@ export class ReadPaginator {
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `read_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.DANGER,
                 `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -487,7 +518,7 @@ export class ReadPaginator {
                                 Constants.TextInputStyles.SHORT,
                                 this.client.translate("main.page.enter"),
                                 "page_number",
-                                "5"
+                                this.embed.toString()
                             )
                             .toJSON(),
                         customID: `jumpto_page_modal_${this.interaction.id}`,
@@ -592,45 +623,57 @@ export class ReadPaginator {
     public updatePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_page_${this.interaction.id}`,
+                `${this.embed} / ${this.embeds.length}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `home_${this.interaction.id}`,
-                this.client.translate("main.home")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🏠",
+                }
             )
             .toJSON();
 

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -76,7 +76,7 @@ export class ReadSearchPaginator {
     ) {
         this.client = client;
         this.embed = 1;
-        this.embeds = gallery.pages.map((page, index) => {
+        this.embeds = gallery.pages.map((page) => {
             return new EmbedBuilder()
                 .setAuthor(
                     gallery.id.toString(),
@@ -84,12 +84,7 @@ export class ReadSearchPaginator {
                     this.client.api.getImageURL(page)
                 )
                 .setColor(client.config.BOT.COLOUR)
-                .setFooter(
-                    client.translate("main.page", {
-                        firstIndex: index + 1,
-                        lastIndex: gallery.pages.length,
-                    })
-                )
+                .setFooter(`⭐ ${gallery.favorites.toLocaleString()}`)
                 .setImage(this.client.api.getImageURL(page))
                 .setTitle(gallery.title.pretty)
                 .setURL(`https://nhentai.net/g/${gallery.id}`)
@@ -108,45 +103,57 @@ export class ReadSearchPaginator {
     public async initialisePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_page_${this.interaction.id}`,
+                `${this.embed} / ${this.embeds.length}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `home_result_${this.interaction.id}`,
-                this.client.translate("main.home")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🏠",
+                }
             )
             .toJSON();
 
@@ -332,7 +339,7 @@ export class ReadSearchPaginator {
                                 Constants.TextInputStyles.SHORT,
                                 this.client.translate("main.page.enter"),
                                 "page_number",
-                                "5"
+                                this.embed.toString()
                             )
                             .toJSON(),
                         customID: `jumpto_page_modal_${this.interaction.id}`,
@@ -437,45 +444,57 @@ export class ReadSearchPaginator {
     public updatePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_page_${this.interaction.id}`,
+                `${this.embed} / ${this.embeds.length}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
                 `home_result_${this.interaction.id}`,
-                this.client.translate("main.home")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🏠",
+                }
             )
             .toJSON();
 

--- a/framework/lib/Modules/ReadSearchPaginator.ts
+++ b/framework/lib/Modules/ReadSearchPaginator.ts
@@ -129,12 +129,12 @@ export class ReadSearchPaginator {
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
+                Constants.ButtonStyles.PRIMARY,
+                `home_result_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🗑",
+                    name: "🏠",
                 }
             )
             .addInteractionButton(
@@ -147,12 +147,12 @@ export class ReadSearchPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `home_result_${this.interaction.id}`,
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🏠",
+                    name: "🗑",
                 }
             )
             .toJSON();
@@ -470,12 +470,12 @@ export class ReadSearchPaginator {
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_${this.interaction.id}`,
+                Constants.ButtonStyles.PRIMARY,
+                `home_result_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🗑",
+                    name: "🏠",
                 }
             )
             .addInteractionButton(
@@ -488,12 +488,12 @@ export class ReadSearchPaginator {
                 }
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `home_result_${this.interaction.id}`,
+                Constants.ButtonStyles.DANGER,
+                `stop_${this.interaction.id}`,
                 undefined,
                 {
                     id: undefined,
-                    name: "🏠",
+                    name: "🗑",
                 }
             )
             .toJSON();

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -51,11 +51,6 @@ export class SearchPaginator {
     message: Message<TextChannel>;
 
     /**
-     * Total pages of the search
-     */
-    pages: number;
-
-    /**
      * The read paginator
      */
     paginationEmbed: ReadSearchPaginator;
@@ -87,7 +82,6 @@ export class SearchPaginator {
         this.embeds = [];
         this.interaction = interaction;
         this.onSearch = this.onSearch.bind(this);
-        this.pages = search.pages;
         this.running = false;
         this.search = search;
     }
@@ -283,7 +277,7 @@ export class SearchPaginator {
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `jumpto_result_page_${this.interaction.id}`,
-                `${this.search.page.toLocaleString()} / ${this.pages.toLocaleString()}`
+                `${this.search.page.toLocaleString()} / ${this.search.pages.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,

--- a/framework/lib/Modules/SearchPaginator.ts
+++ b/framework/lib/Modules/SearchPaginator.ts
@@ -51,6 +51,11 @@ export class SearchPaginator {
     message: Message<TextChannel>;
 
     /**
+     * Total pages of the search
+     */
+    pages: number;
+
+    /**
      * The read paginator
      */
     paginationEmbed: ReadSearchPaginator;
@@ -82,6 +87,7 @@ export class SearchPaginator {
         this.embeds = [];
         this.interaction = interaction;
         this.onSearch = this.onSearch.bind(this);
+        this.pages = search.pages;
         this.running = false;
         this.search = search;
     }
@@ -239,72 +245,83 @@ export class SearchPaginator {
 
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.search.page.toLocaleString()} / ${this.pages.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -344,72 +361,83 @@ export class SearchPaginator {
 
         const hideComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.search.page.toLocaleString()} / ${this.search.pages.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -420,72 +448,83 @@ export class SearchPaginator {
 
         const showComponent = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.search.page.toLocaleString()} / ${this.search.pages.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
@@ -699,7 +738,7 @@ export class SearchPaginator {
                                 Constants.TextInputStyles.SHORT,
                                 this.client.translate("main.result.enter"),
                                 "result_number",
-                                "10"
+                                this.embed.toString()
                             )
                             .toJSON(),
                         customID: `jumpto_result_modal_${this.interaction.id}`,
@@ -714,7 +753,7 @@ export class SearchPaginator {
                                 Constants.TextInputStyles.SHORT,
                                 this.client.translate("main.page.enter"),
                                 "result_page_number",
-                                "5"
+                                this.search.page.toString()
                             )
                             .toJSON(),
                         customID: `jumpto_result_page_modal_${this.interaction.id}`,
@@ -2107,72 +2146,83 @@ export class SearchPaginator {
     public updatePaginator() {
         const components = new ComponentBuilder<MessageActionRow>()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_${this.interaction.id}`,
-                this.client.translate("main.result.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_${this.interaction.id}`,
-                this.client.translate("main.result.previous")
+                "<"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.DANGER,
-                `stop_result_${this.interaction.id}`,
-                this.client.translate("main.stop")
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_${this.interaction.id}`,
+                `${this.embed.toLocaleString()} / ${this.embeds.length.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_${this.interaction.id}`,
-                this.client.translate("main.result.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_${this.interaction.id}`,
-                this.client.translate("main.result.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `first_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.first")
+                "<<"
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `previous_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.previous")
+                "<"
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.SECONDARY,
+                `jumpto_result_page_${this.interaction.id}`,
+                `${this.search.page.toLocaleString()} / ${this.search.pages.toLocaleString()}`
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `next_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.next")
+                ">"
             )
             .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
+                Constants.ButtonStyles.SECONDARY,
                 `last_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.last")
+                ">>"
             )
             .addRow()
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_${this.interaction.id}`,
-                this.client.translate("main.result.enter")
-            )
-            .addInteractionButton(
-                Constants.ButtonStyles.PRIMARY,
-                `jumpto_result_page_${this.interaction.id}`,
-                this.client.translate("main.page.enter")
-            )
-            .addRow()
-            .addInteractionButton(
-                Constants.ButtonStyles.SUCCESS,
                 `read_result_${this.interaction.id}`,
-                this.client.translate("main.read")
+                undefined,
+                {
+                    id: undefined,
+                    name: "📖",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.SECONDARY,
                 `bookmark_${this.interaction.id}`,
-                this.client.translate("main.bookmark")
+                undefined,
+                {
+                    id: undefined,
+                    name: "🔖",
+                }
+            )
+            .addInteractionButton(
+                Constants.ButtonStyles.DANGER,
+                `stop_result_${this.interaction.id}`,
+                undefined,
+                {
+                    id: undefined,
+                    name: "🗑",
+                }
             )
             .addInteractionButton(
                 Constants.ButtonStyles.PRIMARY,


### PR DESCRIPTION
Rewrite and reorganise the structure of the buttons. This pull request enables buttons to appear more organised and tidy.

## OLD PREVIEW

![image](https://github.com/reinhello/NReader/assets/73813638/a5bb9718-1613-43e7-afe6-14c0581b8272)

## NEW PREVIEW

![image](https://github.com/reinhello/NReader/assets/73813638/ff3861db-0df9-43e0-a233-cb4d167bdb79)

**P.S.** The first row is used to navigate through current page's results. While the second row is used to navigate search pages.
