### PR TITLE
Fix NSFW commands in NSFW-marked thread channels

### DIFF
--- a/framework/lib/Utils/Util.ts
+++ b/framework/lib/Utils/Util.ts
@@ -3,6 +3,7 @@ import {
     CommandInteraction,
     Constants,
     ModalSubmitInteraction,
+    PublicThreadChannel,
     TextChannel,
 } from "oceanic.js";
 import { NReaderClient } from "../Client";
@@ -100,6 +101,23 @@ export class Util {
             client.config.BOT.ADMIN.includes(interaction.member.id)
         ) {
             return command.run(payload);
+        }
+
+        // Check if an NSFW command is run in an NSFW thread channel
+        if (interaction.channel instanceof PublicThreadChannel) {
+            if (command.nsfwOnly && (interaction.guild.channels.get((interaction.channel as PublicThreadChannel).parentID) as TextChannel).nsfw) {
+                return command.run(payload);
+            }
+            if (command.nsfwOnly && !(interaction.guild.channels.get((interaction.channel as PublicThreadChannel).parentID) as TextChannel).nsfw) {
+                return interaction.createMessage({
+                    embeds: [
+                        embed
+                            .setDescription(client.translate("mod.noperms"))
+                            .toJSON(),
+                    ],
+                    flags: Constants.MessageFlags.EPHEMERAL,
+                });
+            }
         }
 
         // Check if an NSFW command is run outside channels marked as NSFW

--- a/framework/lib/Utils/Util.ts
+++ b/framework/lib/Utils/Util.ts
@@ -105,10 +105,25 @@ export class Util {
 
         // Check if an NSFW command is run in an NSFW thread channel
         if (interaction.channel instanceof PublicThreadChannel) {
-            if (command.nsfwOnly && (interaction.guild.channels.get((interaction.channel as PublicThreadChannel).parentID) as TextChannel).nsfw) {
+            if (
+                command.nsfwOnly &&
+                (
+                    interaction.guild.channels.get(
+                        (interaction.channel as PublicThreadChannel).parentID
+                    ) as TextChannel
+                ).nsfw
+            ) {
                 return command.run(payload);
             }
-            if (command.nsfwOnly && !(interaction.guild.channels.get((interaction.channel as PublicThreadChannel).parentID) as TextChannel).nsfw) {
+
+            if (
+                command.nsfwOnly &&
+                !(
+                    interaction.guild.channels.get(
+                        (interaction.channel as PublicThreadChannel).parentID
+                    ) as TextChannel
+                ).nsfw
+            ) {
                 return interaction.createMessage({
                     embeds: [
                         embed


### PR DESCRIPTION
Thread channels that have their parent's channel set to an Age-Restricted Channel have permission to run NSFW commands.